### PR TITLE
feat: Migrate to entry.runtime_data pattern (Bronze tier requirement)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [Unreleased] - Bronze Tier Runtime Data Migration
+
+### Changed
+- **Runtime Data Migration** ⚡ CRITICAL
+  - Migrated from legacy `hass.data[DOMAIN]` to modern `entry.runtime_data` pattern
+  - Affects all platform files (camera, sensor, binary_sensor, switch, select, button, siren)
+  - Battery-specific platforms also migrated (battery_binary_sensor, battery_button, battery_select)
+  - Diagnostics updated to use `entry.runtime_data`
+  - Shared platform_setup.py updated
+  - All 241 unit tests passing ✅
+  - Completes 1 of 4 remaining Bronze tier requirements
+
+### Technical
+- `__init__.py`: Removed `hass.data[DOMAIN]` usage, now sets `entry.runtime_data = coordinator`
+- `async_unload_entry`: Uses `entry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`
+- All platform files updated: 8 files modified
+- Test fixtures updated: MockConfigEntry now has `runtime_data` attribute
+- Test mocks updated: MockHomeAssistant sets `entry.runtime_data` in async_setup
+
+### Quality Scale
+- **Bronze**: 16/19 complete (84%) - Up from 15/19 (79%)
+- **runtime-data**: ✅ DONE (was TODO)
+
+### Tests
+- All unit tests passing: 241 passed, 2 skipped ✅
+- Updated test_diagnostics.py to use `entry.runtime_data`
+- Updated test_init.py to check `entry.runtime_data`
+- Mock fixtures support runtime_data pattern
+
 ## [Unreleased] - Bronze Tier Completion
 
 ### Added

--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -50,9 +50,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up this integration using UI."""
-    if hass.data.get(DOMAIN) is None:
-        hass.data.setdefault(DOMAIN, {})
-
     # Initialize API client and device
     api_client, device = await _setup_api_client_and_device(hass, entry)
 
@@ -62,8 +59,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # Create and configure coordinator
     coordinator = await _setup_coordinator(hass, device, entry)
 
-    # Store coordinator and setup platforms
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    # Store coordinator in runtime_data (modern HA pattern)
+    entry.runtime_data = coordinator
     await _setup_platforms(hass, entry, coordinator)
 
     # Check for rate limiting and notify user if detected
@@ -254,7 +251,7 @@ def _check_rate_limit_status(hass: HomeAssistant, entry: ConfigEntry, coordinato
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
     _LOGGER.debug("Unloading entry %s", entry.entry_id)
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     unloaded = all(
         await asyncio.gather(
             *[
@@ -264,8 +261,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ]
         )
     )
-    if unloaded:
-        hass.data[DOMAIN].pop(entry.entry_id)
     return unloaded
 
 

--- a/custom_components/imou_life/battery_binary_sensor.py
+++ b/custom_components/imou_life/battery_binary_sensor.py
@@ -8,7 +8,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .battery_entity import ImouBatteryEntity
-from .const import DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -17,7 +16,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Imou battery optimization binary sensor platform."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/custom_components/imou_life/battery_button.py
+++ b/custom_components/imou_life/battery_button.py
@@ -15,7 +15,6 @@ from .const import (
     DEFAULT_MOTION_SENSITIVITY,
     DEFAULT_POWER_SAVING_MODE,
     DEFAULT_RECORDING_QUALITY,
-    DOMAIN,
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -25,7 +24,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Imou battery optimization button platform."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/custom_components/imou_life/battery_select.py
+++ b/custom_components/imou_life/battery_select.py
@@ -10,7 +10,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .battery_entity import ImouBatteryEntity
 from .const import (
-    DOMAIN,
     MOTION_SENSITIVITY_LEVELS,
     POWER_MODES,
     RECORDING_QUALITY_OPTIONS,
@@ -24,7 +23,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Imou battery optimization select platform."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
 
     entities = []
 

--- a/custom_components/imou_life/camera.py
+++ b/custom_components/imou_life/camera.py
@@ -60,7 +60,7 @@ async def async_setup_entry(
         "async_service_ptz_move",
     )
 
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     device = coordinator.device
     sensors = []
     for sensor_instance in device.get_sensors_by_platform("camera"):

--- a/custom_components/imou_life/diagnostics.py
+++ b/custom_components/imou_life/diagnostics.py
@@ -6,7 +6,6 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
 from .coordinator import ImouDataUpdateCoordinator
 
 
@@ -14,7 +13,7 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: ImouDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: ImouDataUpdateCoordinator = entry.runtime_data
     to_redact = {
         "app_id",
         "app_secret",

--- a/custom_components/imou_life/platform_setup.py
+++ b/custom_components/imou_life/platform_setup.py
@@ -7,7 +7,6 @@ from typing import Type
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
 from .entity import ImouEntity
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -31,7 +30,7 @@ async def setup_platform(
         entity_id_format: Format string for entity ID
         async_add_devices: Function to add devices to HA
     """
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     device = coordinator.device
     entities = []
 

--- a/custom_components/imou_life/quality_scale.yaml
+++ b/custom_components/imou_life/quality_scale.yaml
@@ -18,7 +18,7 @@ rules:
   entity-event-setup: todo  # Needs verification
   entity-unique-id: done  # Using device IDs
   has-entity-name: todo  # Needs verification across all entities
-  runtime-data: todo  # Currently using hass.data[DOMAIN], need to migrate to entry.runtime_data
+  runtime-data: done  # Migrated from hass.data[DOMAIN] to entry.runtime_data
   test-before-configure: done  # Validates credentials in config flow
   test-before-setup: done  # Validates device initialization
   unique-config-entry: done  # Uses device_id as unique_id

--- a/custom_components/imou_life/sensor.py
+++ b/custom_components/imou_life/sensor.py
@@ -18,7 +18,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
     )
 
     # Add API status diagnostic sensor
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     async_add_devices([ImouAPIStatusSensor(coordinator, entry)], True)
 
 

--- a/custom_components/imou_life/switch.py
+++ b/custom_components/imou_life/switch.py
@@ -7,7 +7,7 @@ from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, ENABLED_SWITCHES, OPTION_CALLBACK_URL
+from .const import ENABLED_SWITCHES, OPTION_CALLBACK_URL
 from .entity import ImouEntity
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -20,7 +20,7 @@ async def async_setup_entry(
     _LOGGER.debug("Setting up switch platform for entry %s", entry.entry_id)
 
     try:
-        coordinator = hass.data[DOMAIN][entry.entry_id]
+        coordinator = entry.runtime_data
         device = coordinator.device
         sensors = []
 

--- a/tests/fixtures/mocks.py
+++ b/tests/fixtures/mocks.py
@@ -74,10 +74,14 @@ class MockConfigEntry(ConfigEntry):
 
         self._hass = None
         self._options = kwargs.get("options", {})
+        self.runtime_data = None  # Initialize runtime_data attribute
 
     def add_to_hass(self, hass):
         """Add this config entry to hass."""
         self._hass = hass
+        # Register this entry in config_entries for mock_async_setup
+        if hasattr(hass.config_entries, "_entries"):
+            hass.config_entries._entries[self.entry_id] = self
         return self
 
     @property
@@ -210,10 +214,6 @@ class MockHomeAssistant:
         """Set up entry setup mocks."""
 
         def mock_async_setup(entry_id):
-            # Store the entry in hass.data for testing
-            if "imou_life" not in self.data:
-                self.data["imou_life"] = {}
-
             # Create a mock coordinator that can pass isinstance checks
             from custom_components.imou_life.coordinator import (
                 ImouDataUpdateCoordinator,
@@ -233,7 +233,11 @@ class MockHomeAssistant:
             mock_device.get_name.return_value = "device_name"
             mock_coordinator.device = mock_device
 
-            self.data["imou_life"][entry_id] = mock_coordinator
+            # Find the config entry and set runtime_data
+            for entry in self.config_entries._entries.values():
+                if entry.entry_id == entry_id:
+                    entry.runtime_data = mock_coordinator
+                    break
 
             # Set up platforms
             from custom_components.imou_life.const import PLATFORMS
@@ -244,6 +248,7 @@ class MockHomeAssistant:
             return True
 
         self.config_entries.async_setup = AsyncMock(side_effect=mock_async_setup)
+        self.config_entries._entries = {}
 
         # Mock async_forward_entry_setups
         def mock_async_forward_entry_setups(entry, platforms):
@@ -258,9 +263,9 @@ class MockHomeAssistant:
                 mock_switch.async_turn_on = AsyncMock()
                 mock_switch.async_turn_off = AsyncMock()
 
-                # Add to coordinator entities
-                coordinator = self.data["imou_life"][entry.entry_id]
-                coordinator.entities.append(mock_switch)
+                # Add to coordinator entities (use runtime_data)
+                if hasattr(entry, "runtime_data") and entry.runtime_data:
+                    entry.runtime_data.entities.append(mock_switch)
 
             return True
 

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -53,8 +53,8 @@ class TestDiagnostics:
         self, mock_hass, mock_config_entry, mock_coordinator
     ):
         """Test config entry diagnostics."""
-        # Mock the coordinator retrieval from hass.data
-        mock_hass.data = {"imou_life": {mock_config_entry.entry_id: mock_coordinator}}
+        # Mock the coordinator retrieval from entry.runtime_data
+        mock_config_entry.runtime_data = mock_coordinator
         mock_coordinator.device.get_diagnostics.return_value = {
             "device_id": "test_device_123",
             "device_name": "Test Device",
@@ -77,11 +77,11 @@ class TestDiagnostics:
     @pytest.mark.asyncio
     async def test_diagnostics_no_coordinator(self, mock_hass, mock_config_entry):
         """Test diagnostics when no coordinator exists."""
-        # Mock empty hass.data
-        mock_hass.data = {"imou_life": {}}
+        # Mock entry.runtime_data as None (not set)
+        mock_config_entry.runtime_data = None
 
-        # This should raise a KeyError since the coordinator doesn't exist
-        with pytest.raises(KeyError):
+        # This should raise an AttributeError since runtime_data is None
+        with pytest.raises(AttributeError):
             await async_get_config_entry_diagnostics(mock_hass, mock_config_entry)
 
     @pytest.mark.asyncio
@@ -89,8 +89,8 @@ class TestDiagnostics:
         self, mock_hass, mock_config_entry, mock_coordinator
     ):
         """Test diagnostics data structure."""
-        # Mock the coordinator retrieval from hass.data
-        mock_hass.data = {"imou_life": {mock_config_entry.entry_id: mock_coordinator}}
+        # Mock the coordinator retrieval from entry.runtime_data
+        mock_config_entry.runtime_data = mock_coordinator
         mock_coordinator.device.get_diagnostics.return_value = {
             "device_id": "test_device_123",
             "device_name": "Test Device",

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -24,21 +24,16 @@ async def test_setup_unload_and_reload_entry(hass, api_ok):
     # test setup entry
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert isinstance(
-        hass.data[DOMAIN][config_entry.entry_id], ImouDataUpdateCoordinator
-    )
+    assert hasattr(config_entry, "runtime_data")
+    assert isinstance(config_entry.runtime_data, ImouDataUpdateCoordinator)
 
     # Reload the entry and assert that the data from above is still there
     assert await async_reload_entry(hass, config_entry) is None
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert isinstance(
-        hass.data[DOMAIN][config_entry.entry_id], ImouDataUpdateCoordinator
-    )
+    assert hasattr(config_entry, "runtime_data")
+    assert isinstance(config_entry.runtime_data, ImouDataUpdateCoordinator)
 
-    # Unload the entry and verify that the data has been removed
+    # Unload the entry and verify that unload succeeds
     assert await async_unload_entry(hass, config_entry)
-    assert config_entry.entry_id not in hass.data[DOMAIN]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Completes the **runtime-data** Bronze tier requirement by migrating from the legacy `hass.data[DOMAIN]` pattern to the modern `entry.runtime_data` pattern introduced in Home Assistant 2024.2+.

## Bronze Tier Progress

**Before**: 15/19 (79%)  
**After**: 16/19 (84%)  
**Requirements Remaining**: 3

## Changes

### Core Integration (`__init__.py`)
- ? `async_setup_entry`: Removed `hass.data.setdefault(DOMAIN, {})`
- ? `async_setup_entry`: Set `entry.runtime_data = coordinator` instead of `hass.data[DOMAIN][entry.entry_id] = coordinator`
- ? `async_unload_entry`: Access coordinator via `entry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`
- ? Removed cleanup code `hass.data[DOMAIN].pop(entry.entry_id)` (no longer needed)

### Platform Files (8 files updated)
All platform files now use `entry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`:

**Core Platforms:**
- `camera.py`
- `sensor.py`
- `switch.py`

**Battery Platforms:**
- `battery_binary_sensor.py`
- `battery_button.py`
- `battery_select.py`

**Support Files:**
- `diagnostics.py`
- `platform_setup.py`

### Code Cleanup
- Removed unused `DOMAIN` imports from all updated files (flake8 compliance)

### Test Updates
Updated test fixtures to support `entry.runtime_data`:

**`tests/fixtures/mocks.py`:**
- `MockConfigEntry`: Added `runtime_data` attribute (initialized to `None`)
- `MockConfigEntry.add_to_hass`: Registers entry in `config_entries._entries` for mock lookup
- `MockHomeAssistant.async_setup`: Sets `entry.runtime_data` instead of `hass.data[DOMAIN][entry_id]`
- `MockHomeAssistant.async_forward_entry_setups`: Uses `entry.runtime_data` for entity operations

**`tests/unit/test_diagnostics.py`:**
- All 3 tests updated to mock `entry.runtime_data` instead of `hass.data[DOMAIN]`
- Changed expected exception from `KeyError` to `AttributeError` when runtime_data is None

**`tests/unit/test_init.py`:**
- `test_setup_unload_and_reload_entry`: Checks `entry.runtime_data` instead of `hass.data[DOMAIN]`
- Removed assertions checking `hass.data[DOMAIN]` cleanup (no longer applicable)

## Benefits

### Modern Pattern
- Follows Home Assistant 2024.2+ best practices
- Better encapsulation (data tied to config entry lifecycle)
- Cleaner code (no manual dictionary management)

### Type Safety
- `entry.runtime_data` is type-hinted in Home Assistant core
- Better IDE autocomplete and type checking

### Lifecycle Management
- Automatic cleanup when entry is removed (no manual `pop()` needed)
- No risk of stale data in `hass.data`

## Testing

? **All 241 unit tests passing**  
? **2 skipped** (expected - existing skipped tests)  
? **Pre-commit hooks passing** (black, flake8, isort, codespell, validate-manifest)

============================= test session starts =============================
platform win32 -- Python 3.14.4, pytest-9.0.0, pluggy-1.6.0 -- c:\Python314\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\Maxim\Projects\imou_life
configfile: pyproject.toml
plugins: anyio-4.13.0, aiohttp-1.1.0, asyncio-1.3.0, cov-7.0.0, pytest_freezer-0.4.9, github-actions-annotate-failures-0.3.0, picked-0.5.1, socket-0.7.0, timeout-2.4.0, unordered-0.7.0, xdist-3.8.0, requests-mock-1.12.1, respx-0.22.0, syrupy-5.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 243 items

tests/unit/test_api_status_sensor.py::TestImouAPIStatusSensor::test_sensor_initialization PASSED [  0%]
tests/unit/test_api_status_sensor.py::TestImouAPIStatusSensor::test_sensor_device_info PASSED [  0%]
tests/unit/test_api_status_sensor.py::TestImouAPIStatusSensor::test_sensor_state_ok PASSED [  1%]
tests/unit/test_api_status_sensor.py::TestImouAPIStatusSensor::test_sensor_state_rate_limited PASSED [  1%]
tests/unit/test_api_status_sensor.py::TestImouAPIStatusSensor::test_sensor_state_error PASSED [  2%]
tests/unit/test_api_status_sensor.py::TestImouAPIStatusSensor::test_sensor_state_unknown PASSED [  2%]
tests/unit/test_api_status_sensor.py::TestImouAPIStatusSensor::test_sensor_attributes_basic PASSED [  2%]
tests/unit/test_api_status_sensor.py::TestImouAPIStatusSensor::test_sensor_attributes_rate_limited PASSED [  3%]
tests/unit/test_api_status_sensor.py::TestImouAPIStatusSensor::test_sensor_attributes_after_recovery PASSED [  3%]
tests/unit/test_api_status_sensor.py::TestImouAPIStatusSensor::test_sensor_attributes_with_error PASSED [  4%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_initialization PASSED [  4%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_name PASSED [  4%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_unique_id PASSED [  5%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_icon PASSED [  5%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_low_battery_sensor_below_threshold PASSED [  6%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_low_battery_sensor_above_threshold PASSED [  6%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_low_battery_sensor_coordinator_method_not_found PASSED [  6%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_charging_sensor_true PASSED [  7%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_charging_sensor_false PASSED [  7%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_power_saving_sensor_active PASSED [  8%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_power_saving_sensor_inactive PASSED [  8%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_power_saving_sensor_coordinator_method_not_found PASSED [  9%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sleep_mode_sensor_active PASSED [  9%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sleep_mode_sensor_inactive PASSED [  9%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sleep_mode_sensor_coordinator_method_not_found PASSED [ 10%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_exception_handling PASSED [ 10%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_available PASSED [ 11%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_available_device_offline PASSED [ 11%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_added_to_hass PASSED [ 11%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_will_remove_from_hass PASSED [ 12%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_device_info PASSED [ 12%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_all_sensor_types PASSED [ 13%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_low_battery_threshold_calculation PASSED [ 13%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_power_saving_status_retrieval PASSED [ 13%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sleep_mode_status_retrieval PASSED [ 14%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_error_logging PASSED [ 14%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_availability_inheritance PASSED [ 15%]
tests/unit/test_battery_binary_sensor.py::TestImouBatteryBinarySensor::test_sensor_entity_registry_integration PASSED [ 15%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_initialization PASSED [ 16%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_name PASSED [ 16%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_unique_id PASSED [ 16%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_icon PASSED [ 17%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_enter_sleep_mode PASSED [ 17%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_exit_sleep_mode PASSED [ 18%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_optimize_battery PASSED [ 18%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_reset_power_settings PASSED [ 18%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_enter_sleep_mode_coordinator_method_not_found PASSED [ 19%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_exit_sleep_mode_coordinator_method_not_found PASSED [ 19%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_optimize_battery_coordinator_method_not_found PASSED [ 20%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_reset_power_settings_with_coordinator_method PASSED [ 20%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_exception_handling PASSED [ 20%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_available PASSED [ 21%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_available_device_offline PASSED [ 21%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_added_to_hass PASSED [ 22%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_will_remove_from_hass PASSED [ 22%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_device_info PASSED [ 23%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_all_button_types PASSED [ 23%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_logging PASSED [ 23%]
tests/unit/test_battery_button.py::TestImouBatteryButton::test_button_press_error_logging PASSED [ 24%]
tests/unit/test_battery_coordinator_data.py::TestBatteryCoordinatorData::test_async_update_data_success PASSED [ 24%]
tests/unit/test_battery_coordinator_data.py::TestBatteryCoordinatorData::test_async_update_data_exception PASSED [ 25%]
tests/unit/test_battery_coordinator_init.py::TestBatteryCoordinatorInit::test_coordinator_initialization PASSED [ 25%]
tests/unit/test_battery_coordinator_init.py::TestBatteryCoordinatorInit::test_coordinator_default_values PASSED [ 25%]
tests/unit/test_battery_coordinator_init.py::TestBatteryCoordinatorInit::test_load_settings_custom_sleep_schedule PASSED [ 26%]
tests/unit/test_battery_coordinator_init.py::TestBatteryCoordinatorInit::test_load_settings_invalid_sleep_times PASSED [ 26%]
tests/unit/test_battery_coordinator_optimization.py::TestBatteryCoordinatorOptimization::test_get_battery_data_success PASSED [ 27%]
tests/unit/test_battery_coordinator_optimization.py::TestBatteryCoordinatorOptimization::test_get_battery_data_exception PASSED [ 27%]
tests/unit/test_battery_coordinator_optimization.py::TestBatteryCoordinatorOptimization::test_check_battery_optimization_below_threshold PASSED [ 27%]
tests/unit/test_battery_coordinator_optimization.py::TestBatteryCoordinatorOptimization::test_check_battery_optimization_above_threshold PASSED [ 28%]
tests/unit/test_battery_coordinator_optimization.py::TestBatteryCoordinatorOptimization::test_check_battery_optimization_no_change PASSED [ 28%]
tests/unit/test_battery_coordinator_optimization.py::TestBatteryCoordinatorOptimization::test_activate_battery_optimization PASSED [ 29%]
tests/unit/test_battery_coordinator_optimization.py::TestBatteryCoordinatorOptimization::test_deactivate_battery_optimization PASSED [ 29%]
tests/unit/test_battery_coordinator_optimization.py::TestBatteryCoordinatorOptimization::test_optimize_battery PASSED [ 30%]
tests/unit/test_battery_coordinator_settings.py::TestBatteryCoordinatorSettings::test_set_motion_sensitivity_valid PASSED [ 30%]
tests/unit/test_battery_coordinator_settings.py::TestBatteryCoordinatorSettings::test_set_motion_sensitivity_invalid PASSED [ 30%]
tests/unit/test_battery_coordinator_settings.py::TestBatteryCoordinatorSettings::test_set_recording_quality_valid PASSED [ 31%]
tests/unit/test_battery_coordinator_settings.py::TestBatteryCoordinatorSettings::test_set_recording_quality_invalid PASSED [ 31%]
tests/unit/test_battery_coordinator_settings.py::TestBatteryCoordinatorSettings::test_set_power_mode_valid PASSED [ 32%]
tests/unit/test_battery_coordinator_settings.py::TestBatteryCoordinatorSettings::test_set_power_mode_invalid PASSED [ 32%]
tests/unit/test_battery_coordinator_settings.py::TestBatteryCoordinatorSettings::test_set_led_indicators PASSED [ 32%]
tests/unit/test_battery_coordinator_settings.py::TestBatteryCoordinatorSettings::test_get_battery_optimization_status PASSED [ 33%]
tests/unit/test_battery_coordinator_sleep.py::TestBatteryCoordinatorSleep::test_check_sleep_schedule_never PASSED [ 33%]
tests/unit/test_battery_coordinator_sleep.py::TestBatteryCoordinatorSleep::test_check_sleep_schedule_night_only PASSED [ 34%]
tests/unit/test_battery_coordinator_sleep.py::TestBatteryCoordinatorSleep::test_check_sleep_schedule_custom_same_day PASSED [ 34%]
tests/unit/test_battery_coordinator_sleep.py::TestBatteryCoordinatorSleep::test_check_sleep_schedule_custom_overnight PASSED [ 34%]
tests/unit/test_battery_coordinator_sleep.py::TestBatteryCoordinatorSleep::test_check_sleep_schedule_battery_based PASSED [ 35%]
tests/unit/test_battery_coordinator_sleep.py::TestBatteryCoordinatorSleep::test_set_sleep_schedule_valid PASSED [ 35%]
tests/unit/test_battery_coordinator_sleep.py::TestBatteryCoordinatorSleep::test_set_sleep_schedule_invalid PASSED [ 36%]
tests/unit/test_battery_coordinator_sleep.py::TestBatteryCoordinatorSleep::test_set_sleep_schedule_with_times PASSED [ 36%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_initialization PASSED [ 37%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_name PASSED [ 37%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_unique_id PASSED [ 37%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_icon PASSED [ 38%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_options PASSED [ 38%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_current_option_from_coordinator PASSED [ 39%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_current_option_from_config PASSED [ 39%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_current_option_fallback PASSED [ 39%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_option_power_mode PASSED [ 40%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_option_motion_sensitivity PASSED [ 40%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_option_recording_quality PASSED [ 41%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_option_sleep_schedule PASSED [ 41%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_option_invalid PASSED [ 41%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_option_updates_config PASSED [ 42%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_option_coordinator_method_not_found PASSED [ 42%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_available PASSED [ 43%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_available_device_offline PASSED [ 43%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_added_to_hass PASSED [ 44%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_will_remove_from_hass PASSED [ 44%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_motion_sensitivity_select_properties PASSED [ 44%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_recording_quality_select_properties PASSED [ 45%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_sleep_schedule_select_properties PASSED [ 45%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_option_exception_handling PASSED [ 46%]
tests/unit/test_battery_select.py::TestImouBatterySelect::test_select_device_info PASSED [ 46%]
tests/unit/test_binary_sensor.py::TestImouBinarySensor::test_binary_sensor_name PASSED [ 46%]
tests/unit/test_binary_sensor.py::TestImouBinarySensor::test_binary_sensor_unique_id PASSED [ 47%]
tests/unit/test_binary_sensor.py::TestImouBinarySensor::test_binary_sensor_should_poll PASSED [ 47%]
tests/unit/test_binary_sensor.py::TestImouBinarySensor::test_binary_sensor_is_on PASSED [ 48%]
tests/unit/test_binary_sensor.py::TestImouBinarySensor::test_binary_sensor_device_class PASSED [ 48%]
tests/unit/test_binary_sensor.py::TestImouBinarySensor::test_binary_sensor_icon PASSED [ 48%]
tests/unit/test_binary_sensor.py::TestImouBinarySensor::test_binary_sensor_available PASSED [ 49%]
tests/unit/test_binary_sensor.py::TestImouBinarySensor::test_binary_sensor_device_info PASSED [ 49%]
tests/unit/test_binary_sensor.py::TestImouBinarySensor::test_binary_sensor_extra_state_attributes PASSED [ 50%]
tests/unit/test_bronze_tier_compliance.py::TestBronzeTierCompliance::test_config_flow_exists PASSED [ 50%]
tests/unit/test_bronze_tier_compliance.py::TestBronzeTierCompliance::test_test_before_configure PASSED [ 51%]
tests/unit/test_bronze_tier_compliance.py::TestBronzeTierCompliance::test_test_before_configure_fails_on_invalid_credentials PASSED [ 51%]
tests/unit/test_bronze_tier_compliance.py::TestBronzeTierCompliance::test_unique_config_entry PASSED [ 51%]
tests/unit/test_bronze_tier_compliance.py::TestBronzeTierCompliance::test_entity_unique_id_format PASSED [ 52%]
tests/unit/test_bronze_tier_compliance.py::TestBronzeTierCompliance::test_has_entity_name_property SKIPPED [ 52%]
tests/unit/test_bronze_tier_compliance.py::TestBronzeTierCompliance::test_service_registration_ptz PASSED [ 53%]
tests/unit/test_bronze_tier_compliance.py::TestBronzeTierCompliance::test_appropriate_polling_interval PASSED [ 53%]
tests/unit/test_bronze_tier_compliance.py::TestBronzeTierCompliance::test_common_modules_exist PASSED [ 53%]
tests/unit/test_bronze_tier_compliance.py::TestBronzeTierCompliance::test_config_entry_unloading PASSED [ 54%]
tests/unit/test_bronze_tier_compliance.py::test_bronze_tier_summary PASSED [ 54%]
tests/unit/test_button.py::TestImouButton::test_button_name PASSED       [ 55%]
tests/unit/test_button.py::TestImouButton::test_button_unique_id PASSED  [ 55%]
tests/unit/test_button.py::TestImouButton::test_button_should_poll PASSED [ 55%]
tests/unit/test_button.py::TestImouButton::test_button_icon PASSED       [ 56%]
tests/unit/test_button.py::TestImouButton::test_button_device_class PASSED [ 56%]
tests/unit/test_button.py::TestImouButton::test_button_available PASSED  [ 57%]
tests/unit/test_button.py::TestImouButton::test_button_press PASSED      [ 57%]
tests/unit/test_button.py::TestImouButton::test_button_device_info PASSED [ 58%]
tests/unit/test_camera.py::TestImouCamera::test_camera_name PASSED       [ 58%]
tests/unit/test_camera.py::TestImouCamera::test_camera_unique_id PASSED  [ 58%]
tests/unit/test_camera.py::TestImouCamera::test_camera_should_poll PASSED [ 59%]
tests/unit/test_camera.py::TestImouCamera::test_camera_image PASSED      [ 59%]
tests/unit/test_camera.py::TestImouCamera::test_camera_stream_source PASSED [ 60%]
tests/unit/test_camera.py::TestImouCamera::test_camera_icon PASSED       [ 60%]
tests/unit/test_camera.py::TestImouCamera::test_camera_available PASSED  [ 60%]
tests/unit/test_camera.py::TestImouCamera::test_camera_device_info PASSED [ 61%]
tests/unit/test_camera.py::TestImouCamera::test_camera_extra_state_attributes PASSED [ 61%]
tests/unit/test_camera.py::TestImouCamera::test_camera_ptz_location_service PASSED [ 62%]
tests/unit/test_camera.py::TestImouCamera::test_camera_ptz_move_service PASSED [ 62%]
tests/unit/test_config_flow.py::test_discover_ok PASSED                  [ 62%]
tests/unit/test_config_flow.py::test_login_error PASSED                  [ 63%]
tests/unit/test_config_flow.py::test_manual_ok PASSED                    [ 63%]
tests/unit/test_config_flow.py::test_options_flow PASSED                 [ 64%]
tests/unit/test_config_flow.py::test_login_with_predefined_server PASSED [ 64%]
tests/unit/test_config_flow.py::test_login_with_custom_server PASSED     [ 65%]
tests/unit/test_config_flow.py::test_custom_server_with_valid_url PASSED [ 65%]
tests/unit/test_config_flow.py::test_all_server_options PASSED           [ 65%]
tests/unit/test_config_flow.py::test_url_field_auto_population PASSED    [ 66%]
tests/unit/test_config_flow.py::test_custom_url_field_validation PASSED  [ 66%]
tests/unit/test_const.py::TestConstants::test_domain_constant PASSED     [ 67%]
tests/unit/test_const.py::TestConstants::test_conf_app_id_constant PASSED [ 67%]
tests/unit/test_const.py::TestConstants::test_conf_app_secret_constant PASSED [ 67%]
tests/unit/test_const.py::TestConstants::test_conf_device_name_constant PASSED [ 68%]
tests/unit/test_const.py::TestConstants::test_conf_device_id_constant PASSED [ 68%]
tests/unit/test_const.py::TestConstants::test_default_scan_interval_constant PASSED [ 69%]
tests/unit/test_const.py::TestConstants::test_default_api_url_constant PASSED [ 69%]
tests/unit/test_const.py::TestConstants::test_platforms_constant PASSED  [ 69%]
tests/unit/test_const.py::TestConstants::test_constants_are_strings PASSED [ 70%]
tests/unit/test_const.py::TestConstants::test_constants_are_integers PASSED [ 70%]
tests/unit/test_const.py::TestConstants::test_platforms_is_list PASSED   [ 71%]
tests/unit/test_coordinator.py::TestImouDataUpdateCoordinator::test_coordinator_initialization PASSED [ 71%]
tests/unit/test_coordinator.py::TestImouDataUpdateCoordinator::test_coordinator_async_update_data_success PASSED [ 72%]
tests/unit/test_coordinator.py::TestImouDataUpdateCoordinator::test_coordinator_async_update_data_failure PASSED [ 72%]
tests/unit/test_coordinator.py::TestImouDataUpdateCoordinator::test_coordinator_platforms PASSED [ 72%]
tests/unit/test_coordinator.py::TestImouDataUpdateCoordinator::test_coordinator_entities PASSED [ 73%]
tests/unit/test_coordinator.py::TestImouDataUpdateCoordinator::test_coordinator_name PASSED [ 73%]
tests/unit/test_coordinator.py::TestImouDataUpdateCoordinator::test_coordinator_update_interval PASSED [ 74%]
tests/unit/test_coordinator_rate_limit.py::TestCoordinatorRateLimitHandling::test_successful_update_clears_rate_limit PASSED [ 74%]
tests/unit/test_coordinator_rate_limit.py::TestCoordinatorRateLimitHandling::test_rate_limit_detection PASSED [ 74%]
tests/unit/test_coordinator_rate_limit.py::TestCoordinatorRateLimitHandling::test_scan_interval_adjustment_on_rate_limit PASSED [ 75%]
tests/unit/test_coordinator_rate_limit.py::TestCoordinatorRateLimitHandling::test_rate_limit_tracking PASSED [ 75%]
tests/unit/test_coordinator_rate_limit.py::TestCoordinatorRateLimitHandling::test_rate_limit_count_increments PASSED [ 76%]
tests/unit/test_coordinator_rate_limit.py::TestCoordinatorRateLimitHandling::test_non_rate_limit_error_handling PASSED [ 76%]
tests/unit/test_coordinator_rate_limit.py::TestCoordinatorRateLimitHandling::test_interval_only_adjusted_once PASSED [ 76%]
tests/unit/test_coordinator_rate_limit.py::TestCoordinatorRateLimitHandling::test_recovery_workflow PASSED [ 77%]
tests/unit/test_diagnostics.py::TestDiagnostics::test_async_get_config_entry_diagnostics PASSED [ 77%]
tests/unit/test_diagnostics.py::TestDiagnostics::test_diagnostics_no_coordinator PASSED [ 78%]
tests/unit/test_diagnostics.py::TestDiagnostics::test_diagnostics_structure PASSED [ 78%]
tests/unit/test_entity.py::TestImouEntity::test_entity_initialization PASSED [ 79%]
tests/unit/test_entity.py::TestImouEntity::test_entity_name PASSED       [ 79%]
tests/unit/test_entity.py::TestImouEntity::test_entity_unique_id PASSED  [ 79%]
tests/unit/test_entity.py::TestImouEntity::test_entity_should_poll PASSED [ 80%]
tests/unit/test_entity.py::TestImouEntity::test_entity_available PASSED  [ 80%]
tests/unit/test_entity.py::TestImouEntity::test_entity_device_info PASSED [ 81%]
tests/unit/test_entity.py::TestImouEntity::test_entity_extra_state_attributes PASSED [ 81%]
tests/unit/test_entity.py::TestImouEntity::test_entity_icon PASSED       [ 81%]
tests/unit/test_entity.py::TestImouEntity::test_entity_async_added_to_hass PASSED [ 82%]
tests/unit/test_entity.py::TestImouEntity::test_entity_async_will_remove_from_hass PASSED [ 82%]
tests/unit/test_init.py::test_setup_unload_and_reload_entry PASSED       [ 83%]
tests/unit/test_init.py::test_setup_entry_exception PASSED               [ 83%]
tests/unit/test_rate_limit_handling.py::test_rate_limit_during_initialization PASSED [ 83%]
tests/unit/test_rate_limit_handling.py::test_rate_limit_during_coordinator_update PASSED [ 84%]
tests/unit/test_rate_limit_handling.py::test_other_api_errors_still_raised PASSED [ 84%]
tests/unit/test_rate_limit_handling.py::test_rate_limit_variations PASSED [ 85%]
tests/unit/test_select.py::TestImouSelect::test_select_name PASSED       [ 85%]
tests/unit/test_select.py::TestImouSelect::test_select_unique_id PASSED  [ 86%]
tests/unit/test_select.py::TestImouSelect::test_select_should_poll PASSED [ 86%]
tests/unit/test_select.py::TestImouSelect::test_select_current_option PASSED [ 86%]
tests/unit/test_select.py::TestImouSelect::test_select_options PASSED    [ 87%]
tests/unit/test_select.py::TestImouSelect::test_select_icon PASSED       [ 87%]
tests/unit/test_select.py::TestImouSelect::test_select_available PASSED  [ 88%]
tests/unit/test_select.py::TestImouSelect::test_select_select_option PASSED [ 88%]
tests/unit/test_select.py::TestImouSelect::test_select_device_info PASSED [ 88%]
tests/unit/test_select.py::TestImouSelect::test_select_extra_state_attributes PASSED [ 89%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_name PASSED       [ 89%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_unique_id PASSED  [ 90%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_should_poll PASSED [ 90%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_state PASSED      [ 90%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_unit_of_measurement PASSED [ 91%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_device_class PASSED [ 91%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_icon PASSED       [ 92%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_available PASSED  [ 92%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_device_info PASSED [ 93%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_extra_state_attributes PASSED [ 93%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_timestamp_device_class PASSED [ 93%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_storage_unit PASSED [ 94%]
tests/unit/test_sensor.py::TestImouSensor::test_sensor_no_device_class_mapping PASSED [ 94%]
tests/unit/test_siren.py::TestImouSiren::test_siren_name PASSED          [ 95%]
tests/unit/test_siren.py::TestImouSiren::test_siren_unique_id PASSED     [ 95%]
tests/unit/test_siren.py::TestImouSiren::test_siren_should_poll PASSED   [ 95%]
tests/unit/test_siren.py::TestImouSiren::test_siren_is_on PASSED         [ 96%]
tests/unit/test_siren.py::TestImouSiren::test_siren_icon PASSED          [ 96%]
tests/unit/test_siren.py::TestImouSiren::test_siren_available PASSED     [ 97%]
tests/unit/test_siren.py::TestImouSiren::test_siren_turn_on PASSED       [ 97%]
tests/unit/test_siren.py::TestImouSiren::test_siren_turn_off PASSED      [ 97%]
tests/unit/test_siren.py::TestImouSiren::test_siren_toggle PASSED        [ 98%]
tests/unit/test_siren.py::TestImouSiren::test_siren_device_info PASSED   [ 98%]
tests/unit/test_siren.py::TestImouSiren::test_siren_extra_state_attributes PASSED [ 99%]
tests/unit/test_siren.py::TestImouSiren::test_siren_supported_features PASSED [ 99%]
tests/unit/test_switch.py::test_switch SKIPPED (Temporarily disabled due
to complex mocking requirements)                                         [100%]

================= 241 passed, 2 skipped, 2 warnings in 0.83s ==================

## Breaking Changes

?? **None**

This is a pure internal refactoring. The public API, user configuration, and entity behavior remain unchanged.

## Quality Scale Status

**Bronze Tier**: 16/19 complete (84%)

**Completed** ?:
- runtime-data (this PR)
- action-setup
- appropriate-polling
- common-modules
- config-flow
- config-flow-test-coverage
- dependency-transparency
- docs-actions
- docs-high-level-description
- docs-installation-instructions
- docs-removal-instructions
- entity-unique-id
- test-before-configure
- test-before-setup
- unique-config-entry
- config-entry-unloading

**Remaining** (3 requirements):
1. **has-entity-name** ? CRITICAL - Requires v2.0.0 (breaking change)
2. **entity-event-setup** ?? MEDIUM - Needs verification
3. **brands** ?? LOW - Logo/icon assets needed

## Related Work

- Follows PR #17 (Bronze tier completion documentation)
- Part of quality scale roadmap documented in `docs/development/QUALITY_SCALE_ROADMAP.md`

## Next Steps

After this PR merges:
1. Implement `has-entity-name` (breaking change, requires v2.0.0)
2. Verify `entity-event-setup` compliance
3. Add branding assets
4. **Achieve full Bronze tier compliance** ??

## Checklist

- [x] Code follows project style (black, flake8, isort)
- [x] All tests passing (241 unit tests)
- [x] Pre-commit hooks passing
- [x] CHANGELOG.md updated
- [x] quality_scale.yaml updated
- [x] No breaking changes
- [x] Test fixtures updated
- [x] Unused imports removed

---

?? Generated with [Claude Code](https://claude.com/claude-code)