### PR TITLE
feat: Implement has_entity_name for Bronze tier compliance

### DIFF
--- a/custom_components/imou_life/entity.py
+++ b/custom_components/imou_life/entity.py
@@ -14,6 +14,8 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 class ImouEntity(CoordinatorEntity):
     """imou entity class."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator, config_entry, sensor_instance, entity_format):
         """Initialize."""
         super().__init__(coordinator)
@@ -56,7 +58,7 @@ class ImouEntity(CoordinatorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{self.device.get_name()} {self.sensor_instance.get_description()}"
+        return self.sensor_instance.get_description()
 
     @property
     def icon(self):

--- a/custom_components/imou_life/quality_scale.yaml
+++ b/custom_components/imou_life/quality_scale.yaml
@@ -17,7 +17,7 @@ rules:
   docs-removal-instructions: done  # docs/UNINSTALL.md added
   entity-event-setup: todo  # Needs verification
   entity-unique-id: done  # Using device IDs
-  has-entity-name: todo  # Needs verification across all entities
+  has-entity-name: done  # Implemented _attr_has_entity_name = True in base entity
   runtime-data: done  # Migrated from hass.data[DOMAIN] to entry.runtime_data
   test-before-configure: done  # Validates credentials in config flow
   test-before-setup: done  # Validates device initialization

--- a/tests/unit/test_binary_sensor.py
+++ b/tests/unit/test_binary_sensor.py
@@ -46,7 +46,8 @@ class TestImouBinarySensor:
 
     def test_binary_sensor_name(self, binary_sensor):
         """Test binary sensor name property."""
-        assert binary_sensor.name == "Test Motion Sensor Motion"
+        # With has_entity_name=True, name is just the sensor description
+        assert binary_sensor.name == "Motion"
 
     def test_binary_sensor_unique_id(self, binary_sensor):
         """Test binary sensor unique ID."""

--- a/tests/unit/test_bronze_tier_compliance.py
+++ b/tests/unit/test_bronze_tier_compliance.py
@@ -136,28 +136,37 @@ class TestBronzeTierCompliance:
                 len(entity.unique_id) > 0
             ), f"Entity {entity.entity_id} has empty unique_id"
 
-    @pytest.mark.skip(reason="has-entity-name is TODO in quality_scale.yaml")
     async def test_has_entity_name_property(self, hass, api_ok):
         """Test: has-entity-name - Entities use has_entity_name = True.
 
         Bronze tier requires entities to set has_entity_name = True for
         proper name composition with device name.
-
-        NOTE: This is currently a TODO item. The test is skipped until
-        the requirement is implemented.
         """
+        from unittest.mock import MagicMock
+
         from custom_components.imou_life.entity import ImouEntity
 
-        # Check that base entity class has the property
-        # Note: This tests the base class - individual entities inherit this
-        assert hasattr(
-            ImouEntity, "_attr_has_entity_name"
-        ), "ImouEntity missing _attr_has_entity_name attribute"
+        # Create a minimal entity instance to test
+        coordinator = MagicMock()
+        coordinator.device.get_name.return_value = "Test Device"
+        coordinator.hass = hass
+        config_entry = MagicMock()
+        config_entry.entry_id = "test"
+        sensor_instance = MagicMock()
+        sensor_instance.get_name.return_value = "test_sensor"
+        sensor_instance.get_description.return_value = "Test Sensor"
 
-        # Verify the attribute is set to True
+        entity = ImouEntity(coordinator, config_entry, sensor_instance, "sensor.{}")
+
+        # Verify has_entity_name is True
         assert (
-            ImouEntity._attr_has_entity_name is True
-        ), "ImouEntity._attr_has_entity_name should be True"
+            entity.has_entity_name is True
+        ), "Entity should have has_entity_name = True"
+
+        # Verify entity name is just the sensor description (not device + sensor)
+        assert (
+            entity.name == "Test Sensor"
+        ), f"Entity name should be just sensor description, got '{entity.name}'"
 
     async def test_service_registration_ptz(self, hass, api_ok):
         """Test: action-setup - PTZ services are registered.
@@ -283,8 +292,8 @@ async def test_bronze_tier_summary(hass):
         "docs-removal-instructions": "✅ PASS - docs/UNINSTALL.md",
         "entity-event-setup": "⚠️  TODO - Needs verification",
         "entity-unique-id": "✅ PASS - Using device IDs",
-        "has-entity-name": "✅ PASS - Base entity has attribute",
-        "runtime-data": "⚠️  TODO - Need to migrate from hass.data",
+        "has-entity-name": "✅ PASS - _attr_has_entity_name = True in base entity",
+        "runtime-data": "✅ PASS - Migrated to entry.runtime_data",
         "test-before-configure": "✅ PASS - Validates credentials",
         "test-before-setup": "✅ PASS - Validates device init",
         "unique-config-entry": "✅ PASS - Uses device_id as unique_id",

--- a/tests/unit/test_button.py
+++ b/tests/unit/test_button.py
@@ -45,7 +45,8 @@ class TestImouButton:
 
     def test_button_name(self, button):
         """Test button name property."""
-        assert button.name == "Test Button Restart"
+        # With has_entity_name=True, name is just the sensor description
+        assert button.name == "Restart"
 
     def test_button_unique_id(self, button):
         """Test button unique ID."""

--- a/tests/unit/test_entity.py
+++ b/tests/unit/test_entity.py
@@ -52,7 +52,8 @@ class TestImouEntity:
 
     def test_entity_name(self, entity):
         """Test entity name property."""
-        assert entity.name == "Test Entity Test"
+        # With has_entity_name=True, name is just the sensor description
+        assert entity.name == "Test"
 
     def test_entity_unique_id(self, entity):
         """Test entity unique ID."""

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -49,7 +49,8 @@ class TestImouSelect:
 
     def test_select_name(self, select):
         """Test select name property."""
-        assert select.name == "Test Select Night Vision"
+        # With has_entity_name=True, name is just the sensor description
+        assert select.name == "Night Vision"
 
     def test_select_unique_id(self, select):
         """Test select unique ID."""

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -44,7 +44,8 @@ class TestImouSensor:
 
     def test_sensor_name(self, sensor):
         """Test sensor name property."""
-        assert sensor.name == "Test Sensor Battery"
+        # With has_entity_name=True, name is just the sensor description
+        assert sensor.name == "Battery"
 
     def test_sensor_unique_id(self, sensor):
         """Test sensor unique ID."""

--- a/tests/unit/test_siren.py
+++ b/tests/unit/test_siren.py
@@ -50,7 +50,8 @@ class TestImouSiren:
 
     def test_siren_name(self, siren):
         """Test siren name property."""
-        assert siren.name == "Test Siren Siren"
+        # With has_entity_name=True, name is just the sensor description
+        assert siren.name == "Siren"
 
     def test_siren_unique_id(self, siren):
         """Test siren unique ID."""


### PR DESCRIPTION
## Summary

Implements the Bronze tier `has-entity-name` requirement by setting `_attr_has_entity_name = True` in the base entity class and updating entity names to use proper Home Assistant naming conventions.

## Changes

- **Entity Base Class** (`entity.py`):
  - Added `_attr_has_entity_name = True` attribute
  - Updated `name` property to return sensor description only (not device + sensor)
  
- **Test Updates**:
  - Enabled `test_has_entity_name_property` (previously skipped)
  - Updated 6 entity test files with corrected name assertions
  - Updated Bronze tier compliance summary
  
- **Documentation**:
  - Marked `has-entity-name` as done in `quality_scale.yaml`
  - Updated Bronze tier progress: 17/19 complete (89%)

## Breaking Change ??

Entity names will change for all users after this update:

- **Before**: "Device Name Sensor Name" (e.g., "Living Room Camera Battery")
- **After**: "Sensor Name" (e.g., "Battery")

Home Assistant automatically prefixes the device name, so the full name visible in the UI remains the same, but the entity name structure follows HA conventions.

**Migration Impact**: Users may need to update automations/scripts that reference entity names directly (rare, as most use entity_id).

## Bronze Tier Progress

- ? **has-entity-name** (this PR)
- ? runtime-data (PR #18)  
- ? 15 other requirements
- ?? entity-event-setup (needs verification)
- ?? brands (needs logo assets)

**Total: 17/19 complete (89%)**

## Testing

- ? 242 unit tests passing
- ? 1 test skipped (unrelated to this change)
- ? All pre-commit hooks passing
- ? Bronze tier compliance test updated and passing

## Related Issues

Part of Bronze tier compliance effort (Quality Scale milestone).

---

?? Generated with [Claude Code](https://claude.com/claude-code)