### PR TITLE
fix: add type hints and improve reauth device name fallback

### DIFF
--- a/custom_components/imou_life/config_flow.py
+++ b/custom_components/imou_life/config_flow.py
@@ -1,10 +1,12 @@
 """Config flow for Imou."""
 
 import logging
+from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from imouapi.api import ImouAPIClient
 from imouapi.device import ImouDevice, ImouDiscoverService
@@ -245,12 +247,14 @@ class ImouFlowHandler(config_entries.ConfigFlow, domain="imou_life"):
         await self.async_set_unique_id(device.get_device_id())
         return self.async_create_entry(title=name, data=data)
 
-    async def async_step_reauth(self, entry_data):
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
         """Handle reauthentication."""
         self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(self, user_input=None):
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Confirm reauthentication."""
         errors = {}
 
@@ -340,7 +344,7 @@ class ImouFlowHandler(config_entries.ConfigFlow, domain="imou_life"):
             ),
             errors=errors,
             description_placeholders={
-                "device_name": self.entry.data.get(CONF_DEVICE_NAME, self.entry.title)
+                "device_name": self.entry.data.get(CONF_DEVICE_NAME) or self.entry.title
             },
         )
 


### PR DESCRIPTION
## Description

Addresses final CodeRabbit nitpick comments from PR #23.

## Changes

### 1. Add Type Hints to Reauth Flow Methods
- Import `FlowResult` from `homeassistant.data_entry_flow`
- Import `Any` from `typing`
- Add type annotations to `async_step_reauth(entry_data: dict[str, Any]) -> FlowResult`
- Add type annotations to `async_step_reauth_confirm(user_input: dict[str, Any] | None = None) -> FlowResult`
- Improves mypy compliance and code maintainability

### 2. Fix Empty Device Name Fallback
- **Issue**: `dict.get(key, default)` only uses default if key is missing, not if value is empty/None
- **Fix**: Changed from `.get(CONF_DEVICE_NAME, self.entry.title)` to `.get(CONF_DEVICE_NAME) or self.entry.title`
- Prevents blank device names in reauth form when CONF_DEVICE_NAME is empty string or None
- Ensures users always see a meaningful device name

## Testing
- ? All 247 unit tests passing
- ? Pre-commit hooks passing (black, flake8, isort, codespell)

## Related
- Addresses review comments from #23
- Part of Silver tier quality scale improvements