### PR TITLE
feat: implement UI device deletion support (async_remove_config_entry_device)

### DIFF
--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -340,8 +340,9 @@ async def async_remove_config_entry_device(
     )
 
     # Check if this device belongs to this config entry by comparing identifiers
+    # Note: Entities use config_entry.entry_id as the device identifier, not device_id
     for identifier in device_entry.identifiers:
-        if identifier[0] == DOMAIN and identifier[1] == device_id:
+        if identifier[0] == DOMAIN and identifier[1] == config_entry.entry_id:
             _LOGGER.debug(
                 "Device '%s' belongs to this config entry, allowing removal",
                 device_name,

--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.typing import ConfigType
 from imouapi.api import ImouAPIClient
 from imouapi.device import ImouDevice
@@ -314,6 +315,45 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
     return unloaded
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Remove a device from the integration.
+
+    Called when the user clicks the delete button on a device.
+    Returns True if the device can be removed, False otherwise.
+
+    Since each config entry corresponds to exactly one device in our integration,
+    we allow removal of the device. This will also remove the config entry if
+    it's the only one associated with this device.
+    """
+    device_id = config_entry.data.get(CONF_DEVICE_ID)
+    device_name = config_entry.data.get(CONF_DEVICE_NAME, "Unknown")
+
+    _LOGGER.info(
+        "User requested deletion of device '%s' (ID: %s) from config entry %s",
+        device_name,
+        device_id,
+        config_entry.entry_id,
+    )
+
+    # Check if this device belongs to this config entry by comparing identifiers
+    for identifier in device_entry.identifiers:
+        if identifier[0] == DOMAIN and identifier[1] == device_id:
+            _LOGGER.debug(
+                "Device '%s' belongs to this config entry, allowing removal",
+                device_name,
+            )
+            return True
+
+    # If the device doesn't match this config entry, don't allow removal
+    _LOGGER.debug(
+        "Device does not belong to config entry %s, preventing removal",
+        config_entry.entry_id,
+    )
+    return False
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/gold_tier_verification.md
+++ b/gold_tier_verification.md
@@ -189,14 +189,19 @@
 
 ### ✅ 21. stale-devices
 **Requirement:** Stale devices are removed
-**Status:** IMPLEMENTED
+**Status:** FULLY IMPLEMENTED
 **Evidence:**
-- Automatic detection in `coordinator.py` (`_is_stale_device_error()`)
-- Monitors for "device not found" API errors
-- 3-failure threshold prevents false positives
-- Creates repair issue for user-confirmed removal
-- Differentiates stale device from auth/rate limit/network errors
-- See `docs/STALE_DEVICE_DETECTION.md` for implementation details
+- **Automatic detection** in `coordinator.py` (`_is_stale_device_error()`)
+  - Monitors for "device not found" API errors
+  - 3-failure threshold prevents false positives
+  - Creates repair issue for user-confirmed removal
+  - Differentiates stale device from auth/rate limit/network errors
+- **Manual deletion support** via `async_remove_config_entry_device()` in `__init__.py`
+  - Enables UI delete button in Settings → Devices & Services
+  - Validates device belongs to config entry before allowing removal
+  - Returns True for safe removal, False otherwise
+  - 4 comprehensive unit tests in `test_device_removal.py`
+- See `docs/STALE_DEVICE_DETECTION.md` for full implementation details
 
 ---
 

--- a/tests/unit/test_device_removal.py
+++ b/tests/unit/test_device_removal.py
@@ -25,9 +25,10 @@ async def test_async_remove_config_entry_device_matching_device(hass: HomeAssist
     )
 
     # Create a mock device entry with matching identifier
+    # Note: Entities use config_entry.entry_id as device identifier, not device_id
     device_entry = DeviceEntry(
         id="device_id_123",
-        identifiers={(DOMAIN, "test_device_123")},
+        identifiers={(DOMAIN, "test_entry_id")},  # Matches config_entry.entry_id
         manufacturer="Imou",
         model="Test Model",
         name="Test Camera",
@@ -87,11 +88,12 @@ async def test_async_remove_config_entry_device_multiple_identifiers(
     )
 
     # Create a mock device entry with multiple identifiers (one matches)
+    # Note: Entities use config_entry.entry_id as device identifier
     device_entry = DeviceEntry(
         id="device_id_123",
         identifiers={
             ("other_domain", "other_id"),
-            (DOMAIN, "test_device_123"),  # This one matches
+            (DOMAIN, "test_entry_id"),  # This one matches config_entry.entry_id
         },
         manufacturer="Imou",
         model="Test Model",
@@ -105,28 +107,32 @@ async def test_async_remove_config_entry_device_multiple_identifiers(
 
 @pytest.mark.asyncio
 async def test_async_remove_config_entry_device_no_device_id(hass: HomeAssistant):
-    """Test device removal when config entry has no device_id."""
+    """Test device removal when config entry has no device_id in data.
+
+    This test verifies that device_id in config data is not required for removal,
+    since the function compares against config_entry.entry_id, not device_id.
+    """
     # Create a mock config entry without device_id (edge case)
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
             CONF_DEVICE_NAME: "Test Camera",
-            # Missing CONF_DEVICE_ID
+            # Missing CONF_DEVICE_ID - but this doesn't affect removal logic
         },
         entry_id="test_entry_id",
         version=3,
         title="Test Camera",
     )
 
-    # Create a mock device entry
+    # Create a mock device entry with non-matching identifier
     device_entry = DeviceEntry(
         id="device_id_123",
-        identifiers={(DOMAIN, "test_device_123")},
+        identifiers={(DOMAIN, "test_device_123")},  # Doesn't match entry_id
         manufacturer="Imou",
         model="Test Model",
         name="Test Camera",
     )
 
-    # Should return False - can't match without device_id
+    # Should return False - identifier doesn't match config_entry.entry_id
     result = await async_remove_config_entry_device(hass, config_entry, device_entry)
     assert result is False

--- a/tests/unit/test_device_removal.py
+++ b/tests/unit/test_device_removal.py
@@ -1,0 +1,132 @@
+"""Test device removal functionality."""
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from custom_components.imou_life import async_remove_config_entry_device
+from custom_components.imou_life.const import CONF_DEVICE_ID, CONF_DEVICE_NAME, DOMAIN
+from tests.fixtures.mocks import MockConfigEntry
+
+
+@pytest.mark.asyncio
+async def test_async_remove_config_entry_device_matching_device(hass: HomeAssistant):
+    """Test that matching device can be removed."""
+    # Create a mock config entry
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "test_device_123",
+            CONF_DEVICE_NAME: "Test Camera",
+        },
+        entry_id="test_entry_id",
+        version=3,
+        title="Test Camera",
+    )
+
+    # Create a mock device entry with matching identifier
+    device_entry = DeviceEntry(
+        id="device_id_123",
+        identifiers={(DOMAIN, "test_device_123")},
+        manufacturer="Imou",
+        model="Test Model",
+        name="Test Camera",
+    )
+
+    # Should return True - device belongs to this config entry
+    result = await async_remove_config_entry_device(hass, config_entry, device_entry)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_async_remove_config_entry_device_non_matching_device(
+    hass: HomeAssistant,
+):
+    """Test that non-matching device cannot be removed."""
+    # Create a mock config entry
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "test_device_123",
+            CONF_DEVICE_NAME: "Test Camera",
+        },
+        entry_id="test_entry_id",
+        version=3,
+        title="Test Camera",
+    )
+
+    # Create a mock device entry with different identifier
+    device_entry = DeviceEntry(
+        id="device_id_456",
+        identifiers={(DOMAIN, "different_device_456")},
+        manufacturer="Imou",
+        model="Test Model",
+        name="Different Camera",
+    )
+
+    # Should return False - device doesn't belong to this config entry
+    result = await async_remove_config_entry_device(hass, config_entry, device_entry)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_async_remove_config_entry_device_multiple_identifiers(
+    hass: HomeAssistant,
+):
+    """Test device removal with multiple identifiers."""
+    # Create a mock config entry
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "test_device_123",
+            CONF_DEVICE_NAME: "Test Camera",
+        },
+        entry_id="test_entry_id",
+        version=3,
+        title="Test Camera",
+    )
+
+    # Create a mock device entry with multiple identifiers (one matches)
+    device_entry = DeviceEntry(
+        id="device_id_123",
+        identifiers={
+            ("other_domain", "other_id"),
+            (DOMAIN, "test_device_123"),  # This one matches
+        },
+        manufacturer="Imou",
+        model="Test Model",
+        name="Test Camera",
+    )
+
+    # Should return True - one of the identifiers matches
+    result = await async_remove_config_entry_device(hass, config_entry, device_entry)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_async_remove_config_entry_device_no_device_id(hass: HomeAssistant):
+    """Test device removal when config entry has no device_id."""
+    # Create a mock config entry without device_id (edge case)
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_NAME: "Test Camera",
+            # Missing CONF_DEVICE_ID
+        },
+        entry_id="test_entry_id",
+        version=3,
+        title="Test Camera",
+    )
+
+    # Create a mock device entry
+    device_entry = DeviceEntry(
+        id="device_id_123",
+        identifiers={(DOMAIN, "test_device_123")},
+        manufacturer="Imou",
+        model="Test Model",
+        name="Test Camera",
+    )
+
+    # Should return False - can't match without device_id
+    result = await async_remove_config_entry_device(hass, config_entry, device_entry)
+    assert result is False


### PR DESCRIPTION
## Summary
Implements `async_remove_config_entry_device` callback to enable manual device deletion from the Home Assistant UI.

## Changes

### Implementation
- **Added `async_remove_config_entry_device()` callback** in `__init__.py`
  - Enables delete button in Settings ? Devices & Services UI
  - Validates device belongs to config entry via identifier matching
  - Returns `True` for safe removal, `False` to prevent deletion
  - Added `DeviceEntry` import from `helpers.device_registry`

### Testing
- **Created `test_device_removal.py`** with 4 comprehensive unit tests:
  - v `test_async_remove_config_entry_device_matching_device` - Returns True for matching device
  - v `test_async_remove_config_entry_device_non_matching_device` - Returns False for non-matching device
  - v `test_async_remove_config_entry_device_multiple_identifiers` - Handles multiple identifiers correctly
  - v `test_async_remove_config_entry_device_no_device_id` - Returns False when device_id missing
- **All 396 unit tests passing** v

### Documentation
- **Updated `gold_tier_verification.md`**
  - Documents both automatic detection (repair flow) and manual deletion (UI)
  - Marks stale-devices requirement as FULLY IMPLEMENTED

### Bug Fix (commit 2)
- **Fixed identifier comparison bug** (caught by CodeRabbit)
  - Was comparing against `CONF_DEVICE_ID` instead of `config_entry.entry_id`
  - Entities register with `(DOMAIN, config_entry.entry_id)` not device_id
  - Updated implementation and all unit tests
  - All 396 tests passing v

## Gold Tier Impact

**Completes stale-devices requirement:**
- v **Automatic detection**: Monitors API errors, creates repair issues (existing)
- v **Manual deletion**: UI delete button support (new)
- v **User control**: Both automatic repair flow + manual UI deletion

## How It Works

1. User navigates to Settings ? Devices & Services ? [Device]
2. Clicks delete button (? menu ? Delete)
3. Home Assistant calls `async_remove_config_entry_device()`
4. Function validates device belongs to this config entry
5. Returns `True` ? device can be deleted
6. Returns `False` ? deletion prevented

## Testing Instructions

1. Install integration with a device
2. Go to Settings ? Devices & Services
3. Find the device, click ? menu ? Delete
4. Confirm deletion
5. Verify device is removed from UI

Generated with [Claude Code](https://claude.com/claude-code)