### PR TITLE
fix: resolve httpx dependency conflict with Home Assistant

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,8 +39,9 @@ updates:
       # Ignore Home Assistant major version updates (require manual testing)
       - dependency-name: "homeassistant"
         update-types: ["version-update:semver-major"]
-      # Ignore aiohttp updates (version controlled by homeassistant dependency)
+      # Ignore aiohttp and httpx updates (versions controlled by homeassistant dependency)
       - dependency-name: "aiohttp"
+      - dependency-name: "httpx"
     groups:
       python-dependencies:
         patterns:

--- a/config/requirements_test.txt
+++ b/config/requirements_test.txt
@@ -8,7 +8,7 @@
 # Maximum Python version: 3.13
 
 # HTTP and async dependencies
-# aiohttp version controlled by homeassistant dependency
+# aiohttp and httpx versions controlled by homeassistant dependency
 
 # Coverage
 coverage>=7.4.0; python_version>="3.11"
@@ -19,7 +19,6 @@ coverage>=7.4.0; python_version>="3.11"
 # Python 3.13: 2025.1.0+ (minimum supported)
 # Using 2024.2+ as it's compatible with Python 3.11-3.13
 homeassistant>=2024.2.0; python_version>="3.11"
-httpx>=0.24.0; python_version>="3.11"
 
 # Integration runtime dependencies
 imouapi==1.0.15; python_version>="3.11"


### PR DESCRIPTION
## Problem

Dependabot PR #41 failed due to httpx dependency conflict:
- Dependabot upgraded: `httpx>=0.28.1`
- Home Assistant 2024.3.3 pins: `httpx==0.27.0` (exact version)
- Result: pip dependency resolution failure

```
ERROR: Cannot install homeassistant 2024.3.3 and httpx>=0.28.1
because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested httpx>=0.28.1
    homeassistant 2024.3.3 depends on httpx==0.27.0
```

## Root Cause

Home Assistant pins httpx to specific versions for stability (same issue as aiohttp in PR #40). Our explicit `httpx>=0.24.0` requirement in `config/requirements_test.txt` conflicts with HA's exact version pins, preventing Dependabot from updating packages.

## Solution

1. **Remove explicit httpx requirement** from `config/requirements_test.txt`
   - httpx version now controlled by homeassistant dependency
   - Prevents future conflicts with HA version pins

2. **Configure Dependabot to ignore httpx**
   - Added to `.github/dependabot.yml` ignore list
   - Home Assistant manages this dependency - we should not override

## Testing

- √ Pre-commit checks will validate
- √ Dependency resolution will be tested in CI
- √ No functional changes - httpx still present via HA dependency

## Related

- Closes #41 (httpx dependency conflict)
- Complements #40 (aiohttp fix - already merged)
- Prevents future Dependabot conflicts with HTTP client dependencies

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
