### PR TITLE
fix: update Sphinx and myst-parser version constraints for compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
 docs = [
     "sphinx>=8.0.0,<10.0.0",
     "myst-parser>=5.0.0,<6.0.0",
-    "sphinx-rtd-theme>=1.3.0,<4.0.0",
+    "sphinx-rtd-theme>=3.1.0,<4.0.0",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,9 @@ dev = [
     "coverage>=7.0.0",
 ]
 docs = [
-    "sphinx>=6.0.0,<8.0.0",
-    "myst-parser>=1.0.0,<3.0.0",
-    "sphinx-rtd-theme>=1.3.0,<3.0.0",
+    "sphinx>=8.0.0,<10.0.0",
+    "myst-parser>=5.0.0,<6.0.0",
+    "sphinx-rtd-theme>=1.3.0,<4.0.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Problem

PR #43 (Dependabot) wants to upgrade `myst-parser` to 5.0.0, but this conflicts with `pyproject.toml`:

**Conflict**:
- `config/requirements.txt`: `myst_parser>=5.0.0` (Dependabot upgrade)
- `pyproject.toml` docs extra: `myst-parser>=1.0.0,<3.0.0` (current constraint)
- `pyproject.toml` docs extra: `sphinx>=6.0.0,<8.0.0` (current constraint)

**Issue**: myst-parser 5.0.0 requires Sphinx >=8.0.0, which our pyproject.toml currently prohibits.

## Root Cause

CodeRabbit identified this in PR #43 review - we have conflicting version constraints between dependency files. The docs extra in pyproject.toml is outdated and blocks the Dependabot upgrade.

## Solution

Update `pyproject.toml` docs extra to align with myst-parser 5.0.0 requirements:

**Changes**:
- `sphinx`: 6.0.0-8.0.0 → **8.0.0-10.0.0**
- `myst-parser`: 1.0.0-3.0.0 → **5.0.0-6.0.0**
- `sphinx-rtd-theme`: 1.3.0-3.0.0 → **1.3.0-4.0.0**

## Testing

- √ Pre-commit hooks pass
- √ No code changes, only dependency constraints
- √ Allows PR #43 to merge cleanly

## Related

- Blocks #43 (Dependabot python-dependencies) - must merge before #43
- Identified by CodeRabbit review on PR #43

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
