### PR TITLE
fix: auto-cleanup orphan devices on entry setup

### DIFF
--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.typing import ConfigType
@@ -55,6 +56,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up this integration using UI."""
+    _cleanup_orphan_devices(hass, entry)
+
     # Initialize API client and device
     api_client, device = await _setup_api_client_and_device(hass, entry)
 
@@ -196,6 +199,31 @@ def _configure_device_options(device: ImouDevice, entry: ConfigEntry):
     if wait_after_wakeup is not None:
         _LOGGER.debug("Setting wait after wakeup to %f", wait_after_wakeup)
         device.set_wait_after_wakeup(wait_after_wakeup)
+
+
+def _cleanup_orphan_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Remove devices whose config entry no longer exists."""
+    try:
+        device_registry = dr.async_get(hass)
+        active_entry_ids = {
+            e.entry_id for e in hass.config_entries.async_entries(DOMAIN)
+        }
+
+        for device_entry in list(device_registry.devices.values()):
+            imou_ids = [
+                eid for domain, eid in device_entry.identifiers if domain == DOMAIN
+            ]
+            if not imou_ids:
+                continue
+
+            if not any(eid in active_entry_ids for eid in imou_ids):
+                _LOGGER.info(
+                    "Removing orphan device '%s' (no matching config entry)",
+                    device_entry.name,
+                )
+                device_registry.async_remove_device(device_entry.id)
+    except Exception:
+        _LOGGER.debug("Orphan device cleanup skipped (registry not ready)")
 
 
 async def _initialize_device(

--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -222,8 +222,8 @@ def _cleanup_orphan_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
                     device_entry.name,
                 )
                 device_registry.async_remove_device(device_entry.id)
-    except Exception:
-        _LOGGER.debug("Orphan device cleanup skipped (registry not ready)")
+    except (KeyError, AttributeError) as err:
+        _LOGGER.debug("Orphan device cleanup skipped: %s", err)
 
 
 async def _initialize_device(

--- a/tests/unit/test_orphan_cleanup.py
+++ b/tests/unit/test_orphan_cleanup.py
@@ -1,0 +1,123 @@
+"""Test orphan device cleanup functionality."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from custom_components.imou_life import _cleanup_orphan_devices
+from custom_components.imou_life.const import DOMAIN
+from tests.fixtures.mocks import MockConfigEntry
+
+
+def _make_device_entry(device_id, identifiers):
+    """Create a DeviceEntry with given identifiers."""
+    return DeviceEntry(id=device_id, identifiers=identifiers)
+
+
+def _make_registry(device_entries):
+    """Create a mock device registry with a devices collection."""
+    registry = MagicMock()
+    devices = MagicMock()
+    devices.values.return_value = device_entries
+    registry.devices = devices
+    return registry
+
+
+def _make_hass(active_entries):
+    """Create a mock hass with config entries and device registry."""
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = active_entries
+    return hass
+
+
+class TestCleanupOrphanDevices:
+    """Tests for _cleanup_orphan_devices."""
+
+    def test_removes_orphan_device(self):
+        """Orphan device (entry_id not in active entries) is removed."""
+        orphan = _make_device_entry("dev1", {(DOMAIN, "deleted_entry_id")})
+        registry = _make_registry([orphan])
+
+        active_entry = MockConfigEntry(
+            domain=DOMAIN, data={}, entry_id="active_entry_id"
+        )
+        hass = _make_hass([active_entry])
+
+        with patch("custom_components.imou_life.dr.async_get", return_value=registry):
+            _cleanup_orphan_devices(hass, active_entry)
+
+        registry.async_remove_device.assert_called_once_with("dev1")
+
+    def test_keeps_active_device(self):
+        """Device whose entry_id matches a live config entry is kept."""
+        active_device = _make_device_entry("dev1", {(DOMAIN, "active_entry_id")})
+        registry = _make_registry([active_device])
+
+        active_entry = MockConfigEntry(
+            domain=DOMAIN, data={}, entry_id="active_entry_id"
+        )
+        hass = _make_hass([active_entry])
+
+        with patch("custom_components.imou_life.dr.async_get", return_value=registry):
+            _cleanup_orphan_devices(hass, active_entry)
+
+        registry.async_remove_device.assert_not_called()
+
+    def test_ignores_non_domain_devices(self):
+        """Devices from other integrations are never touched."""
+        other_device = _make_device_entry("dev1", {("other_domain", "some_id")})
+        registry = _make_registry([other_device])
+
+        active_entry = MockConfigEntry(
+            domain=DOMAIN, data={}, entry_id="active_entry_id"
+        )
+        hass = _make_hass([active_entry])
+
+        with patch("custom_components.imou_life.dr.async_get", return_value=registry):
+            _cleanup_orphan_devices(hass, active_entry)
+
+        registry.async_remove_device.assert_not_called()
+
+    def test_mixed_devices_only_orphan_removed(self):
+        """Only orphan is removed when mixed with active and foreign devices."""
+        active_device = _make_device_entry("dev1", {(DOMAIN, "active_entry_id")})
+        orphan = _make_device_entry("dev2", {(DOMAIN, "deleted_entry_id")})
+        foreign = _make_device_entry("dev3", {("other", "x")})
+        registry = _make_registry([active_device, orphan, foreign])
+
+        active_entry = MockConfigEntry(
+            domain=DOMAIN, data={}, entry_id="active_entry_id"
+        )
+        hass = _make_hass([active_entry])
+
+        with patch("custom_components.imou_life.dr.async_get", return_value=registry):
+            _cleanup_orphan_devices(hass, active_entry)
+
+        registry.async_remove_device.assert_called_once_with("dev2")
+
+    def test_registry_not_ready_does_not_raise(self):
+        """AttributeError from registry is caught gracefully."""
+        active_entry = MockConfigEntry(
+            domain=DOMAIN, data={}, entry_id="active_entry_id"
+        )
+        hass = _make_hass([active_entry])
+
+        with patch(
+            "custom_components.imou_life.dr.async_get",
+            side_effect=AttributeError("not ready"),
+        ):
+            _cleanup_orphan_devices(hass, active_entry)
+
+    def test_key_error_during_removal_does_not_raise(self):
+        """KeyError from async_remove_device is caught gracefully."""
+        orphan = _make_device_entry("dev1", {(DOMAIN, "deleted_entry_id")})
+        registry = _make_registry([orphan])
+        registry.async_remove_device.side_effect = KeyError("dev1")
+
+        active_entry = MockConfigEntry(
+            domain=DOMAIN, data={}, entry_id="active_entry_id"
+        )
+        hass = _make_hass([active_entry])
+
+        with patch("custom_components.imou_life.dr.async_get", return_value=registry):
+            _cleanup_orphan_devices(hass, active_entry)


### PR DESCRIPTION
## Summary
- Adds `_cleanup_orphan_devices()` to remove stale device registry entries at the start of `async_setup_entry`
- Fixes duplicate devices appearing when a config entry is deleted and re-added (old device keyed by previous `entry_id` was left behind)
- Rate-limited or temporarily unavailable devices are safe -- their config entries still exist, so they are never considered orphans

## Test plan
- [x] All 467 unit tests pass
- [x] All pre-commit hooks pass
- [ ] Verify orphan "Garage Cam" disappears after HA restart
- [ ] Verify rate-limited devices are not removed during backoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The integration now automatically cleans up orphaned devices from the device registry during setup, helping maintain a cleaner system state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximunited/imou_life/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->