### PR TITLE
fix: handle oversized identifier tuples in orphan cleanup

### DIFF
--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -211,7 +211,9 @@ def _cleanup_orphan_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
         for device_entry in list(device_registry.devices.values()):
             imou_ids = [
-                eid for domain, eid in device_entry.identifiers if domain == DOMAIN
+                ident[1]
+                for ident in device_entry.identifiers
+                if len(ident) >= 2 and ident[0] == DOMAIN
             ]
             if not imou_ids:
                 continue
@@ -222,7 +224,7 @@ def _cleanup_orphan_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
                     device_entry.name,
                 )
                 device_registry.async_remove_device(device_entry.id)
-    except (KeyError, AttributeError) as err:
+    except (KeyError, AttributeError, ValueError) as err:
         _LOGGER.debug("Orphan device cleanup skipped: %s", err)
 
 

--- a/tests/unit/test_orphan_cleanup.py
+++ b/tests/unit/test_orphan_cleanup.py
@@ -121,3 +121,16 @@ class TestCleanupOrphanDevices:
 
         with patch("custom_components.imou_life.dr.async_get", return_value=registry):
             _cleanup_orphan_devices(hass, active_entry)
+
+    def test_handles_oversized_identifier_tuples(self):
+        """Identifiers with more than 2 elements don't cause ValueError."""
+        bad_device = _make_device_entry("dev1", {(DOMAIN, "id1", "extra1", "extra2")})
+        registry = _make_registry([bad_device])
+
+        active_entry = MockConfigEntry(
+            domain=DOMAIN, data={}, entry_id="active_entry_id"
+        )
+        hass = _make_hass([active_entry])
+
+        with patch("custom_components.imou_life.dr.async_get", return_value=registry):
+            _cleanup_orphan_devices(hass, active_entry)


### PR DESCRIPTION
## Summary
- Fixes `ValueError: too many values to unpack (expected 2, got 4)` in `_cleanup_orphan_devices`
- Some devices have identifier tuples with more than 2 elements; switched from tuple unpacking to index access with length guard
- Added `ValueError` to exception handler as additional safety
- Added test for oversized identifier tuples

## Test plan
- [x] All 474 unit tests pass
- [x] All pre-commit hooks pass
- [x] New test covers the exact failure case (4-element identifier tuple)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of device cleanup operations to properly handle edge cases involving malformed device identifiers.

* **Tests**
  * Added test coverage for device cleanup handling of oversized identifier tuples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximunited/imou_life/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->