### PR TITLE
fix: scale rate limit backoff with hit count

### DIFF
--- a/custom_components/imou_life/rate_limit_manager.py
+++ b/custom_components/imou_life/rate_limit_manager.py
@@ -139,10 +139,11 @@ class RateLimitManager:
             # Don't delete the state - let a successful API call clear it
             return False, None
 
-        # Check if we're within the minimum backoff period
+        # Scale backoff with hit count to avoid repeated retries
+        scaled_backoff = RATE_LIMIT_BACKOFF_SECONDS * state.hit_count
         time_since_last_error = (now - state.last_rate_limit_time).total_seconds()
-        if time_since_last_error < RATE_LIMIT_BACKOFF_SECONDS:
-            backoff_remaining = RATE_LIMIT_BACKOFF_SECONDS - int(time_since_last_error)
+        if time_since_last_error < scaled_backoff:
+            backoff_remaining = scaled_backoff - int(time_since_last_error)
             data = {
                 "backoff_seconds": backoff_remaining,
                 "reset_time": state.estimated_reset_time.strftime("%H:%M:%S"),


### PR DESCRIPTION
## Summary
- Fixes infinite rate limit retry loop where backoff was fixed at 300s regardless of consecutive failures
- Backoff now scales with `hit_count`: 5min (hit 1), 10min (hit 2), 15min (hit 3), etc.
- Capped by the 1-hour estimated reset time (existing logic at line 134)

## Problem
After hitting a rate limit, the integration retried every 5 minutes indefinitely, hitting the API each time and never recovering. Logs showed `hit #1`, `hit #2`, `hit #3`... with the same 300s backoff window between each.

## Test plan
- [x] All 474 unit tests pass (including 19 rate limit tests)
- [x] All pre-commit hooks pass
- [ ] Verify rate limit recovery on real HA instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)