### PR TITLE
fix: stop probing after 3 rate limit failures and wait for reset

### DIFF
--- a/custom_components/imou_life/const.py
+++ b/custom_components/imou_life/const.py
@@ -138,7 +138,10 @@ STALE_DEVICE_ERROR_PATTERNS = [
 
 # Rate limit handling
 RATE_LIMIT_BACKOFF_SECONDS = 300  # 5 minutes minimum backoff
-RATE_LIMIT_RESET_ESTIMATE_HOURS = 1  # Imou API typically resets hourly
+RATE_LIMIT_RESET_ESTIMATE_HOURS = (
+    6  # OP1013 "total" limit is daily; wait conservatively
+)
+RATE_LIMIT_MAX_PROBE_RETRIES = 3  # Stop probing after this many consecutive failures
 RATE_LIMIT_CACHE_KEY = "rate_limit_state"
 
 # switches which are enabled by default

--- a/custom_components/imou_life/rate_limit_manager.py
+++ b/custom_components/imou_life/rate_limit_manager.py
@@ -139,10 +139,11 @@ class RateLimitManager:
             # Don't delete the state - let a successful API call clear it
             return False, None
 
-        # Check if we're within the minimum backoff period
+        # Scale backoff with hit count to avoid repeated retries
+        scaled_backoff = RATE_LIMIT_BACKOFF_SECONDS * state.hit_count
         time_since_last_error = (now - state.last_rate_limit_time).total_seconds()
-        if time_since_last_error < RATE_LIMIT_BACKOFF_SECONDS:
-            backoff_remaining = RATE_LIMIT_BACKOFF_SECONDS - int(time_since_last_error)
+        if time_since_last_error < scaled_backoff:
+            backoff_remaining = scaled_backoff - int(time_since_last_error)
             data = {
                 "backoff_seconds": backoff_remaining,
                 "reset_time": state.estimated_reset_time.strftime("%H:%M:%S"),

--- a/custom_components/imou_life/rate_limit_manager.py
+++ b/custom_components/imou_life/rate_limit_manager.py
@@ -15,6 +15,7 @@ from .const import (
     DOMAIN,
     RATE_LIMIT_BACKOFF_SECONDS,
     RATE_LIMIT_CACHE_KEY,
+    RATE_LIMIT_MAX_PROBE_RETRIES,
     RATE_LIMIT_RESET_ESTIMATE_HOURS,
 )
 
@@ -80,12 +81,9 @@ class RateLimitManager:
         now = dt_util.utcnow()
 
         if key in storage:
-            # Update existing state
+            # Update existing state but keep original estimated_reset_time
             state = storage[key]
             state.last_rate_limit_time = now
-            state.estimated_reset_time = now + timedelta(
-                hours=RATE_LIMIT_RESET_ESTIMATE_HOURS
-            )
             state.error_message = error_message
             state.hit_count += 1
         else:
@@ -156,8 +154,26 @@ class RateLimitManager:
             )
             return True, data
 
-        # We're past the minimum backoff but before estimated reset
-        # Allow retry attempt - if it fails, we'll update the state again
+        # Past backoff but before estimated reset
+        if state.hit_count >= RATE_LIMIT_MAX_PROBE_RETRIES:
+            # Too many consecutive failures — wait for estimated reset
+            remaining = int((state.estimated_reset_time - now).total_seconds())
+            data = {
+                "backoff_seconds": remaining,
+                "reset_time": state.estimated_reset_time.strftime("%H:%M:%S"),
+                "error": state.error_message,
+            }
+            _LOGGER.debug(
+                "Rate limit for app_id %s: %d consecutive hits, "
+                "waiting for reset at %s (%ds remaining)",
+                app_id,
+                state.hit_count,
+                state.estimated_reset_time.strftime("%H:%M:%S"),
+                remaining,
+            )
+            return True, data
+
+        # Allow probe retry
         _LOGGER.debug(
             "Rate limit backoff period expired for app_id %s, allowing retry attempt",
             app_id,


### PR DESCRIPTION
## Summary
- OP1013 "Call interface times exceed limit (total)" is a **daily** quota, not hourly
- After 3 consecutive rate limit hits, the integration now **stops probing** and waits for the estimated reset time (6h) instead of retrying every backoff period
- `estimated_reset_time` is no longer pushed forward on each hit -- it stays anchored to the first hit so it eventually expires
- With previous behavior: 12+ API hits over 6 hours, never recovering. With this fix: 3 API hits then silence until reset

## Changes
- `RATE_LIMIT_RESET_ESTIMATE_HOURS`: 1 -> 6 (matches daily quota reality)
- `RATE_LIMIT_MAX_PROBE_RETRIES`: new constant (3)
- `record_rate_limit`: no longer resets `estimated_reset_time` on subsequent hits
- `is_rate_limited`: blocks until reset time after 3+ consecutive failures

## Test plan
- [x] All 474 unit tests pass (including 19 rate limit tests)
- [x] All pre-commit hooks pass
- [ ] Verify on real HA instance: after 3 hits, no more API calls until reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined rate limit reset time estimates to be more conservative, improving stability during service disruptions.
  * Implemented dynamically scaled backoff calculations based on request frequency to better manage API quota usage.
  * Enhanced rate limit enforcement with mandatory wait periods following excessive consecutive requests for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maximunited/imou_life/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->