### PR TITLE
feat: add tiered polling to reduce API call volume by 66%

### DIFF
--- a/custom_components/imou_life/const.py
+++ b/custom_components/imou_life/const.py
@@ -144,6 +144,12 @@ RATE_LIMIT_RESET_ESTIMATE_HOURS = (
 RATE_LIMIT_MAX_PROBE_RETRIES = 3  # Stop probing after this many consecutive failures
 RATE_LIMIT_CACHE_KEY = "rate_limit_state"
 
+# Tiered polling — reduce API calls by polling slow-changing sensors less often
+FULL_POLL_CYCLE_INTERVAL = (
+    4  # Full poll every 4th cycle; others are fast (critical only)
+)
+CRITICAL_SENSOR_NAMES = {"motionAlarm"}  # Binary sensors polled every cycle
+
 # switches which are enabled by default
 ENABLED_SWITCHES = [
     "motionDetect",

--- a/custom_components/imou_life/coordinator.py
+++ b/custom_components/imou_life/coordinator.py
@@ -15,9 +15,11 @@ from .const import (
     CONF_APP_ID,
     CONF_APP_SECRET,
     CONF_DEVICE_ID,
+    CRITICAL_SENSOR_NAMES,
     DEFAULT_API_URL,
     DEFAULT_DISCOVERY_INTERVAL,
     DOMAIN,
+    FULL_POLL_CYCLE_INTERVAL,
     OPTION_DISCOVERY_INTERVAL,
     STALE_DEVICE_ERROR_PATTERNS,
 )
@@ -54,6 +56,9 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator):
         self._original_scan_interval: int = scan_interval
         self._is_interval_adjusted: bool = False
 
+        # Tiered polling — full poll every Nth cycle, fast poll otherwise
+        self._poll_cycle: int = -1
+
         # Stale device tracking
         self.stale_device_suspected: bool = False
         self.stale_device_failure_count: int = 0
@@ -87,8 +92,14 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """HA calls this every DEFAULT_SCAN_INTERVAL to run the update."""
+        self._poll_cycle += 1
+        is_full_cycle = self._poll_cycle % FULL_POLL_CYCLE_INTERVAL == 0
+
         try:
-            data = await self.device.async_get_data()
+            if is_full_cycle:
+                data = await self.device.async_get_data()
+            else:
+                data = await self._async_fast_update()
 
             # Update succeeded - check if recovering from rate limit
             was_rate_limited = self.is_rate_limited
@@ -197,6 +208,17 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator):
                 error_msg = f"Imou API error: {error_str}"
                 _LOGGER.error(error_msg)
                 raise UpdateFailed(error_msg) from exception
+
+    async def _async_fast_update(self):
+        """Poll only critical sensors (online status + motion alarm)."""
+        await self.device.async_refresh_status()
+
+        if self.device.is_online():
+            for sensor in self.device.get_sensors_by_platform("binary_sensor"):
+                if sensor.get_name() in CRITICAL_SENSOR_NAMES:
+                    await sensor.async_update()
+
+        return True
 
     def _adjust_scan_interval_for_rate_limit(self):
         """Increase scan interval when rate limited to reduce API calls."""

--- a/tests/unit/test_coordinator_rate_limit.py
+++ b/tests/unit/test_coordinator_rate_limit.py
@@ -25,12 +25,23 @@ class TestCoordinatorRateLimitHandling:
         """Create a mock ImouDevice."""
         device = MagicMock()
         device.async_get_data = AsyncMock()
+        device.async_refresh_status = AsyncMock()
+        device.is_online = MagicMock(return_value=True)
+        device.get_sensors_by_platform = MagicMock(return_value=[])
         return device
 
     @pytest.fixture
     def coordinator(self, hass, mock_device):
-        """Create a coordinator instance."""
-        return ImouDataUpdateCoordinator(hass, mock_device, scan_interval=900)
+        """Create a coordinator with every call forced to full cycle."""
+        coord = ImouDataUpdateCoordinator(hass, mock_device, scan_interval=900)
+        _orig = coord._async_update_data
+
+        async def _full_cycle():
+            coord._poll_cycle = -1
+            return await _orig()
+
+        coord._async_update_data = _full_cycle
+        return coord
 
     @pytest.mark.asyncio
     async def test_successful_update_clears_rate_limit(self, coordinator, mock_device):

--- a/tests/unit/test_rate_limit_handling.py
+++ b/tests/unit/test_rate_limit_handling.py
@@ -63,6 +63,7 @@ async def test_rate_limit_during_coordinator_update(hass):
     )
 
     # Update should raise UpdateFailed (not the raw APIError)
+    coordinator._poll_cycle = -1
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
 
@@ -117,6 +118,7 @@ async def test_rate_limit_variations(hass):
 
     for error_msg in rate_limit_messages:
         mock_device.async_get_data.side_effect = APIError(error_msg)
+        coordinator._poll_cycle = -1
 
         with pytest.raises(UpdateFailed):
             await coordinator._async_update_data()

--- a/tests/unit/test_stale_device_detection.py
+++ b/tests/unit/test_stale_device_detection.py
@@ -17,6 +17,10 @@ def mock_device():
     """Create a mock ImouDevice."""
     device = Mock()
     device.async_get_data = AsyncMock()
+    device.async_refresh_status = AsyncMock()
+    device.is_online = Mock(return_value=True)
+    device.get_sensors_by_platform = Mock(return_value=[])
+    device.get_all_sensors = Mock(return_value=[])
     device.get_name = Mock(return_value="Test Camera")
     device.get_device_id = Mock(return_value="test_device_123")
     device.get_model = Mock(return_value="Test Model")
@@ -38,14 +42,27 @@ def mock_config_entry():
 
 @pytest.fixture
 def coordinator(hass: HomeAssistant, mock_device, mock_config_entry):
-    """Create a coordinator instance for testing."""
-    coordinator = ImouDataUpdateCoordinator(
+    """Create a coordinator instance for testing.
+
+    Sets _poll_cycle so every _async_update_data() call is a full cycle,
+    ensuring async_get_data() is always called (not fast-cycle shortcut).
+    """
+    coord = ImouDataUpdateCoordinator(
         hass,
         mock_device,
         900,
         mock_config_entry,
     )
-    return coordinator
+    coord._poll_cycle = -1
+    # Ensure every call triggers a full cycle by wrapping update
+    _orig_update = coord._async_update_data
+
+    async def _full_cycle_update():
+        coord._poll_cycle = -1
+        return await _orig_update()
+
+    coord._async_update_data = _full_cycle_update
+    return coord
 
 
 async def test_is_stale_device_error_detects_patterns(hass: HomeAssistant, coordinator):


### PR DESCRIPTION
## Summary
- Adds tiered polling: fast cycles poll only critical sensors (2 API calls), full cycles poll everything (~16 calls)
- Fast cycles run 3 out of every 4 polls; full cycle every 4th
- Reduces daily API calls from ~1,536 to ~528 per device, preventing OP1013 daily quota exhaustion

## How it works
| Cycle | Sensors polled | API calls |
|-------|---------------|-----------|
| Fast (3/4) | online status + motionAlarm | 2 |
| Full (1/4) | all switches, selects, sensors | ~16 |

## Changes
- `const.py`: New constants `FULL_POLL_CYCLE_INTERVAL` and `CRITICAL_SENSOR_NAMES`
- `coordinator.py`: Poll cycle counter + `_async_fast_update()` method
- Test fixtures updated to support tiered polling

## Test plan
- [x] All 474 unit tests pass
- [x] All pre-commit hooks pass
- [ ] Verify on real HA: fast cycles show ~2 API calls, full cycles ~16
- [ ] Monitor daily API call count stays under quota

🤖 Generated with [Claude Code](https://claude.com/claude-code)