### PR TITLE
fix: reset rate limit cycle when estimated reset time expires

### DIFF
--- a/custom_components/imou_life/rate_limit_manager.py
+++ b/custom_components/imou_life/rate_limit_manager.py
@@ -81,11 +81,17 @@ class RateLimitManager:
         now = dt_util.utcnow()
 
         if key in storage:
-            # Update existing state but keep original estimated_reset_time
             state = storage[key]
+            if now >= state.estimated_reset_time:
+                # Previous wait expired but API is still limited — fresh cycle
+                state.estimated_reset_time = now + timedelta(
+                    hours=RATE_LIMIT_RESET_ESTIMATE_HOURS
+                )
+                state.hit_count = 1
+            else:
+                state.hit_count += 1
             state.last_rate_limit_time = now
             state.error_message = error_message
-            state.hit_count += 1
         else:
             # Create new state
             storage[key] = RateLimitState(

--- a/tests/unit/test_rate_limit_manager.py
+++ b/tests/unit/test_rate_limit_manager.py
@@ -196,6 +196,44 @@ def test_reset_after_estimated_time(rate_limit_mgr: RateLimitManager) -> None:
     assert is_limited is False
 
 
+def test_fresh_cycle_after_expired_reset(rate_limit_mgr: RateLimitManager) -> None:
+    """Test that a new rate limit hit after expired reset starts a fresh cycle.
+
+    Regression test: previously, recording a hit after estimated_reset_time
+    kept the old (past) reset time, so is_rate_limited always returned False
+    and the integration hammered the API indefinitely.
+    """
+    app_id = "test_app_id"
+    app_secret = "test_secret"
+
+    # Simulate 3 hits (exhausts probe retries)
+    for _ in range(3):
+        rate_limit_mgr.record_rate_limit(app_id, app_secret, "OP1013")
+
+    state = rate_limit_mgr.get_state(app_id, app_secret)
+    assert state.hit_count == 3
+
+    # Simulate reset time passing
+    state.estimated_reset_time = dt_util.utcnow() - timedelta(minutes=1)
+    state.last_rate_limit_time = dt_util.utcnow() - timedelta(hours=1)
+
+    # Should allow retry now
+    is_limited, _ = rate_limit_mgr.is_rate_limited(app_id, app_secret)
+    assert is_limited is False
+
+    # API still rate limited — record hit #4
+    rate_limit_mgr.record_rate_limit(app_id, app_secret, "OP1013 again")
+
+    # Must start a fresh cycle: hit_count resets, new estimated_reset_time
+    state = rate_limit_mgr.get_state(app_id, app_secret)
+    assert state.hit_count == 1
+    assert state.estimated_reset_time > dt_util.utcnow()
+
+    # Should be rate limited again (within backoff)
+    is_limited, _ = rate_limit_mgr.is_rate_limited(app_id, app_secret)
+    assert is_limited is True
+
+
 def test_message_content(rate_limit_mgr: RateLimitManager) -> None:
     """Test that rate limit data contains useful information."""
     app_id = "test_app_id"

--- a/tests/unit/test_rate_limit_manager.py
+++ b/tests/unit/test_rate_limit_manager.py
@@ -8,6 +8,7 @@ from homeassistant.util import dt as dt_util
 
 from custom_components.imou_life.const import (
     RATE_LIMIT_BACKOFF_SECONDS,
+    RATE_LIMIT_MAX_PROBE_RETRIES,
     RATE_LIMIT_RESET_ESTIMATE_HOURS,
 )
 from custom_components.imou_life.rate_limit_manager import RateLimitManager
@@ -206,12 +207,12 @@ def test_fresh_cycle_after_expired_reset(rate_limit_mgr: RateLimitManager) -> No
     app_id = "test_app_id"
     app_secret = "test_secret"
 
-    # Simulate 3 hits (exhausts probe retries)
-    for _ in range(3):
+    # Exhaust probe retries
+    for _ in range(RATE_LIMIT_MAX_PROBE_RETRIES):
         rate_limit_mgr.record_rate_limit(app_id, app_secret, "OP1013")
 
     state = rate_limit_mgr.get_state(app_id, app_secret)
-    assert state.hit_count == 3
+    assert state.hit_count == RATE_LIMIT_MAX_PROBE_RETRIES
 
     # Simulate reset time passing
     state.estimated_reset_time = dt_util.utcnow() - timedelta(minutes=1)


### PR DESCRIPTION
## Summary

- Fixes infinite API retry loop when rate limit persists beyond the 6-hour estimated reset window
- When `record_rate_limit()` was called after `estimated_reset_time` had passed, it kept the old (past) reset time and incremented `hit_count` -- this caused `is_rate_limited()` to always return `False`, letting the integration hammer the API every ~80 seconds indefinitely (100+ hits observed in production logs)
- Now starts a fresh cycle (`hit_count=1`, new 6-hour window) when recording a hit after the previous reset time expired

## Test plan

- [x] Regression test `test_fresh_cycle_after_expired_reset` added and passing
- [x] All 475 unit tests passing
- [x] Pre-commit hooks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rate-limit window reset behavior to correctly restart the tracking cycle once the previous reset period expires, ensuring more accurate rate-limit recovery timing.

* **Tests**
  * Added regression test to validate proper rate-limit cycle behavior after reset expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->