### PR TITLE
fix: reduce rate limit log spam and handle empty API errors

### DIFF
--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -38,6 +38,7 @@ from .const import (
     PLATFORMS,
 )
 from .coordinator import ImouDataUpdateCoordinator, ImouDiscoveryCoordinator
+from .helpers import exception_message
 from .rate_limit_manager import RateLimitManager
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -267,9 +268,7 @@ async def _initialize_device(
             translation_domain=DOMAIN, translation_key="device_init_timeout"
         ) from None
     except ImouException as exception:
-        error_msg = str(exception) or (
-            f"{type(exception).__name__} ({exception.get_title()})"
-        )
+        error_msg = exception_message(exception)
         # Handle API rate limit errors (OP1013) by recording and requesting retry
         if "OP1013" in error_msg or "exceed limit" in error_msg.lower():
             # Record the rate limit error

--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -243,7 +243,7 @@ async def _initialize_device(
     is_limited, limit_data = rate_limit_mgr.is_rate_limited(app_id, app_secret)
 
     if is_limited:
-        _LOGGER.warning(
+        _LOGGER.debug(
             "Skipping device initialization due to active rate limit: retry in %ds",
             limit_data.get("backoff_seconds", 0) if limit_data else 0,
         )
@@ -267,7 +267,9 @@ async def _initialize_device(
             translation_domain=DOMAIN, translation_key="device_init_timeout"
         ) from None
     except ImouException as exception:
-        error_msg = str(exception)
+        error_msg = str(exception) or (
+            f"{type(exception).__name__} ({exception.get_title()})"
+        )
         # Handle API rate limit errors (OP1013) by recording and requesting retry
         if "OP1013" in error_msg or "exceed limit" in error_msg.lower():
             # Record the rate limit error

--- a/custom_components/imou_life/coordinator.py
+++ b/custom_components/imou_life/coordinator.py
@@ -122,7 +122,9 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator):
             return data
 
         except ImouException as exception:
-            error_str = str(exception)
+            error_str = str(exception) or (
+                f"{type(exception).__name__} ({exception.get_title()})"
+            )
 
             # Check for authentication errors first
             auth_error_patterns = [

--- a/custom_components/imou_life/coordinator.py
+++ b/custom_components/imou_life/coordinator.py
@@ -23,6 +23,7 @@ from .const import (
     OPTION_DISCOVERY_INTERVAL,
     STALE_DEVICE_ERROR_PATTERNS,
 )
+from .helpers import exception_message
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -122,9 +123,7 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator):
             return data
 
         except ImouException as exception:
-            error_str = str(exception) or (
-                f"{type(exception).__name__} ({exception.get_title()})"
-            )
+            error_str = exception_message(exception)
 
             # Check for authentication errors first
             auth_error_patterns = [

--- a/custom_components/imou_life/helpers.py
+++ b/custom_components/imou_life/helpers.py
@@ -2,6 +2,8 @@
 
 import re
 
+from imouapi.exceptions import ImouException
+
 
 def camel_to_snake(name: str) -> str:
     """Convert camelCase to snake_case for translation keys.
@@ -23,3 +25,9 @@ def camel_to_snake(name: str) -> str:
     if not isinstance(name, str):
         return str(name)
     return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def exception_message(exception: ImouException) -> str:
+    """Extract a useful message from an ImouException, even if empty."""
+    msg = str(exception).strip()
+    return msg or f"{type(exception).__name__} ({exception.get_title()})"


### PR DESCRIPTION
## Summary
- Demote repeated "Skipping device initialization due to active rate limit" log from `warning` to `debug` -- the initial rate-limit warning is sufficient, and HA retries were producing 800+ redundant warnings per cycle
- Add fallback for `ImouException` instances with empty messages so logs show the exception type and title (e.g. `ConnectionFailed (connection_failed)`) instead of bare `Imou API error: `

## Test plan
- [x] All 475 unit tests pass
- [ ] Verify rate-limit retry messages no longer appear at warning level in HA logs
- [ ] Trigger an empty `ImouException` and confirm the fallback message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user-facing error messages with more reliable, non-empty fallback text when errors occur.
  * Lowered logging level for API rate-limit situations to reduce warning-level noise and clutter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->