### PR TITLE
feat: Home Assistant 2026.8 compatibility and quality-scale sync

### DIFF
--- a/.github/workflows/ha-compatibility.yml
+++ b/.github/workflows/ha-compatibility.yml
@@ -31,7 +31,7 @@ jobs:
         include:
           # Minimum supported version (HACS / docs floor)
           # Floor is 2025.10: async_register_platform_entity_service for PTZ
-          - ha-version: "2025.10.0"
+          - ha-version: "2025.10.4"
             python-version: "3.13"
             label: "Minimum"
 
@@ -40,9 +40,9 @@ jobs:
             python-version: "3.13"
             label: "Late 2025"
 
-          # Latest stable release (2026.8.x line)
+          # Latest stable (HA 2026.3+ requires Python >=3.14.2)
           - ha-version: "2026.8.1"
-            python-version: "3.13"
+            python-version: "3.14"
             label: "Latest Stable"
 
           # Development/nightly (catch upcoming breaking changes)
@@ -178,9 +178,9 @@ jobs:
           **Trigger**: ${{ github.event_name }}
 
           ### Tested Versions
-          - Minimum Supported: HA 2025.10.0 / Python 3.13
+          - Minimum Supported: HA 2025.10.4 / Python 3.13
           - Late 2025: HA 2025.12.5 / Python 3.13
-          - Latest Stable: HA 2026.8.1 / Python 3.13
+          - Latest Stable: HA 2026.8.1 / Python 3.14
           - Development: HA dev / Python 3.14 (allowed to fail)
 
           ### Note

--- a/.github/workflows/ha-compatibility.yml
+++ b/.github/workflows/ha-compatibility.yml
@@ -30,8 +30,9 @@ jobs:
       matrix:
         include:
           # Minimum supported version (HACS / docs floor)
-          - ha-version: "2024.12.5"
-            python-version: "3.12"
+          # Floor is 2025.10: async_register_platform_entity_service for PTZ
+          - ha-version: "2025.10.0"
+            python-version: "3.13"
             label: "Minimum"
 
           # Late 2025 stable pin
@@ -177,7 +178,7 @@ jobs:
           **Trigger**: ${{ github.event_name }}
 
           ### Tested Versions
-          - Minimum Supported: HA 2024.12.5 / Python 3.12
+          - Minimum Supported: HA 2025.10.0 / Python 3.13
           - Late 2025: HA 2025.12.5 / Python 3.13
           - Latest Stable: HA 2026.8.1 / Python 3.13
           - Development: HA dev / Python 3.14 (allowed to fail)

--- a/.github/workflows/ha-compatibility.yml
+++ b/.github/workflows/ha-compatibility.yml
@@ -29,18 +29,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Minimum supported version (from manifest requirement)
-          - ha-version: "2024.3.3"
-            python-version: "3.11"
-            label: "Minimum"
-
-          # Late 2024 stable
+          # Minimum supported version (HACS / docs floor)
           - ha-version: "2024.12.5"
             python-version: "3.12"
-            label: "Late 2024"
+            label: "Minimum"
 
-          # Latest stable release (2025.1.x line)
-          - ha-version: "2025.1.4"
+          # Late 2025 stable pin
+          - ha-version: "2025.12.5"
+            python-version: "3.13"
+            label: "Late 2025"
+
+          # Latest stable release (2026.8.x line)
+          - ha-version: "2026.8.1"
             python-version: "3.13"
             label: "Latest Stable"
 
@@ -177,13 +177,14 @@ jobs:
           **Trigger**: ${{ github.event_name }}
 
           ### Tested Versions
-          - Minimum Supported: HA 2024.3.3 / Python 3.11
-          - Late 2024: HA 2024.12.5 / Python 3.12
-          - Latest Stable: HA 2025.1.4 / Python 3.13
+          - Minimum Supported: HA 2024.12.5 / Python 3.12
+          - Late 2025: HA 2025.12.5 / Python 3.13
+          - Latest Stable: HA 2026.8.1 / Python 3.13
           - Development: HA dev / Python 3.14 (allowed to fail)
 
           ### Note
-          Mid-2024 versions (2024.6-2024.11) skipped due to josepy dependency conflicts in CI.
+          Intermediate HA releases are not matrixed; use the pins above plus weekly
+          `dev` runs to catch breaking changes.
 
           ### Status
           See detailed results in Actions tab for pass/fail status.

--- a/.github/workflows/ha-compatibility.yml
+++ b/.github/workflows/ha-compatibility.yml
@@ -84,6 +84,10 @@ jobs:
             pip install homeassistant==${{ matrix.ha-version }}
           fi
 
+          # pycares 5.x removed ares_query_a_result; aiodns used by HA 2025.10
+          # still references it. Pin until aiodns/HA resolve the mismatch.
+          pip install 'pycares>=4.9.0,<5'
+
           # Install integration requirements
           pip install imouapi==1.0.15
 

--- a/.github/workflows/ha-compatibility.yml
+++ b/.github/workflows/ha-compatibility.yml
@@ -84,9 +84,11 @@ jobs:
             pip install homeassistant==${{ matrix.ha-version }}
           fi
 
-          # pycares 5.x removed ares_query_a_result; aiodns used by HA 2025.10
-          # still references it. Pin until aiodns/HA resolve the mismatch.
-          pip install 'pycares>=4.9.0,<5'
+          # HA 2025.10 + aiodns 3.5.0 breaks on pycares 5 (missing ares_query_a_result).
+          # HA 2026.8 needs pycares 5 (DNSRecord). Pin only for the 2025.10 matrix cell.
+          if [[ "${{ matrix.ha-version }}" == 2025.10* ]]; then
+            pip install 'pycares>=4.9.0,<5'
+          fi
 
           # Install integration requirements
           pip install imouapi==1.0.15

--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -2,11 +2,12 @@
 
 # https://github.com/maximunited/imou_life
 
+from __future__ import annotations
+
 import asyncio
 import logging
 
 from homeassistant.components import persistent_notification
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
@@ -37,7 +38,11 @@ from .const import (
     OPTION_WAIT_AFTER_WAKE_UP,
     PLATFORMS,
 )
-from .coordinator import ImouDataUpdateCoordinator, ImouDiscoveryCoordinator
+from .coordinator import (
+    ImouConfigEntry,
+    ImouDataUpdateCoordinator,
+    ImouDiscoveryCoordinator,
+)
 from .helpers import exception_message
 from .rate_limit_manager import RateLimitManager
 
@@ -55,7 +60,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ImouConfigEntry):
     """Set up this integration using UI."""
     _cleanup_orphan_devices(hass, entry)
 
@@ -118,7 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
-async def _setup_api_client_and_device(hass: HomeAssistant, entry: ConfigEntry):
+async def _setup_api_client_and_device(hass: HomeAssistant, entry: ImouConfigEntry):
     """Set up API client and device instance."""
     session = async_get_clientsession(hass)
 
@@ -143,7 +148,7 @@ async def _setup_api_client_and_device(hass: HomeAssistant, entry: ConfigEntry):
     return api_client, device
 
 
-def _create_api_client(device_config: dict, session, entry: ConfigEntry):
+def _create_api_client(device_config: dict, session, entry: ImouConfigEntry):
     """Create and configure the API client."""
     api_client = ImouAPIClient(
         device_config["app_id"], device_config["app_secret"], session
@@ -172,7 +177,7 @@ def _parse_timeout_option(timeout_value):
     return timeout_value
 
 
-def _create_device_instance(api_client, device_config: dict, entry: ConfigEntry):
+def _create_device_instance(api_client, device_config: dict, entry: ImouConfigEntry):
     """Create and configure the device instance."""
     device = ImouDevice(api_client, device_config["device_id"])
 
@@ -185,7 +190,7 @@ def _create_device_instance(api_client, device_config: dict, entry: ConfigEntry)
     return device
 
 
-def _configure_device_options(device: ImouDevice, entry: ConfigEntry):
+def _configure_device_options(device: ImouDevice, entry: ImouConfigEntry):
     """Configure device-specific options."""
     camera_wait_before_download = entry.options.get(
         OPTION_CAMERA_WAIT_BEFORE_DOWNLOAD, None
@@ -202,7 +207,7 @@ def _configure_device_options(device: ImouDevice, entry: ConfigEntry):
         device.set_wait_after_wakeup(wait_after_wakeup)
 
 
-def _cleanup_orphan_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
+def _cleanup_orphan_devices(hass: HomeAssistant, entry: ImouConfigEntry) -> None:
     """Remove devices whose config entry no longer exists."""
     try:
         device_registry = dr.async_get(hass)
@@ -230,7 +235,7 @@ def _cleanup_orphan_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 
 async def _initialize_device(
-    device: ImouDevice, entry: ConfigEntry, hass: HomeAssistant
+    device: ImouDevice, entry: ImouConfigEntry, hass: HomeAssistant
 ) -> None:
     """Initialize device with timeout protection and rate limit checking."""
     setup_timeout = entry.options.get(OPTION_SETUP_TIMEOUT, SETUP_TIMEOUT)
@@ -306,7 +311,7 @@ async def _initialize_device(
 
 
 async def _setup_coordinator(
-    hass: HomeAssistant, device: ImouDevice, entry: ConfigEntry
+    hass: HomeAssistant, device: ImouDevice, entry: ImouConfigEntry
 ):
     """Set up and initialize coordinator."""
     coordinator = ImouDataUpdateCoordinator(
@@ -369,7 +374,7 @@ async def _setup_coordinator(
     return coordinator
 
 
-async def _setup_platforms(hass: HomeAssistant, entry: ConfigEntry, coordinator):
+async def _setup_platforms(hass: HomeAssistant, entry: ImouConfigEntry, coordinator):
     """Set up all platforms."""
     # Add platforms to coordinator
     for platform in PLATFORMS:
@@ -380,7 +385,7 @@ async def _setup_platforms(hass: HomeAssistant, entry: ConfigEntry, coordinator)
     entry.add_update_listener(async_reload_entry)
 
 
-def _check_rate_limit_status(hass: HomeAssistant, entry: ConfigEntry, coordinator):
+def _check_rate_limit_status(hass: HomeAssistant, entry: ImouConfigEntry, coordinator):
     """Check for rate limiting and notify user if detected."""
     if coordinator.is_rate_limited:
         device_name = coordinator.device.get_name()
@@ -409,7 +414,7 @@ def _check_rate_limit_status(hass: HomeAssistant, entry: ConfigEntry, coordinato
 
 async def _create_stale_device_repair_issue(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ImouConfigEntry,
     coordinator: ImouDataUpdateCoordinator,
 ) -> None:
     """Create a repair issue for stale device."""
@@ -429,7 +434,7 @@ async def _create_stale_device_repair_issue(
     )
 
 
-def _is_first_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+def _is_first_entry(hass: HomeAssistant, entry: ImouConfigEntry) -> bool:
     """Check if this is the first config entry."""
     entries = hass.config_entries.async_entries(DOMAIN)
     if not entries:
@@ -438,7 +443,7 @@ def _is_first_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _setup_discovery_coordinator(
-    hass: HomeAssistant, api_client, entry: ConfigEntry
+    hass: HomeAssistant, api_client, entry: ImouConfigEntry
 ):
     """Set up discovery coordinator."""
     # Check if discovery is enabled
@@ -454,7 +459,7 @@ async def _setup_discovery_coordinator(
 
 
 async def _transfer_discovery_to_next_entry(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: ImouConfigEntry
 ) -> None:
     """Transfer discovery coordinator to next entry when first entry is removed."""
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -474,7 +479,7 @@ async def _transfer_discovery_to_next_entry(
         await hass.config_entries.async_reload(remaining_entries[0].entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ImouConfigEntry) -> bool:
     """Handle removal of an entry."""
     _LOGGER.debug("Unloading entry %s", entry.entry_id)
 
@@ -505,7 +510,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_remove_config_entry_device(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+    hass: HomeAssistant, config_entry: ImouConfigEntry, device_entry: DeviceEntry
 ) -> bool:
     """Remove a device from the integration.
 
@@ -544,13 +549,13 @@ async def async_remove_config_entry_device(
     return False
 
 
-async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_reload_entry(hass: HomeAssistant, entry: ImouConfigEntry) -> None:
     """Reload config entry."""
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)
 
 
-async def async_migrate_entry(hass, config_entry: ConfigEntry) -> bool:
+async def async_migrate_entry(hass, config_entry: ImouConfigEntry) -> bool:
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s", config_entry.version)
     data = {**config_entry.data}

--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -69,7 +69,8 @@ SETUP_TIMEOUT = 30
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Imou Life integration (services; YAML config not supported)."""
     # Register PTZ entity services at integration setup so registration does
-    # not depend on camera platform load (HA 2025.10+ pattern).
+    # not depend on camera platform load. Requires Home Assistant 2025.10+
+    # (async_register_platform_entity_service); matches hacs.json floor.
     service.async_register_platform_entity_service(
         hass,
         DOMAIN,

--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -5,20 +5,29 @@
 import asyncio
 import logging
 
+import voluptuous as vol
 from homeassistant.components import persistent_notification
+from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import service
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.typing import ConfigType
 from imouapi.api import ImouAPIClient
+from imouapi.const import PTZ_OPERATIONS
 from imouapi.device import ImouDevice
 from imouapi.exceptions import ImouException
 
 from .const import (
+    ATTR_PTZ_DURATION,
+    ATTR_PTZ_HORIZONTAL,
+    ATTR_PTZ_OPERATION,
+    ATTR_PTZ_VERTICAL,
+    ATTR_PTZ_ZOOM,
     CONF_API_URL,
     CONF_APP_ID,
     CONF_APP_SECRET,
@@ -36,6 +45,8 @@ from .const import (
     OPTION_SETUP_TIMEOUT,
     OPTION_WAIT_AFTER_WAKE_UP,
     PLATFORMS,
+    SERVIZE_PTZ_LOCATION,
+    SERVIZE_PTZ_MOVE,
 )
 from .coordinator import ImouDataUpdateCoordinator, ImouDiscoveryCoordinator
 from .helpers import exception_message
@@ -50,8 +61,35 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 SETUP_TIMEOUT = 30
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType):
-    """Set up this integration using YAML is not supported."""
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Imou Life integration (services; YAML config not supported)."""
+    # Register PTZ entity services at integration setup so registration does
+    # not depend on camera platform load (HA 2025.10+ pattern).
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVIZE_PTZ_LOCATION,
+        entity_domain=CAMERA_DOMAIN,
+        schema={
+            vol.Required(ATTR_PTZ_HORIZONTAL, default=0): vol.Range(min=-1, max=1),
+            vol.Required(ATTR_PTZ_VERTICAL, default=0): vol.Range(min=-1, max=1),
+            vol.Required(ATTR_PTZ_ZOOM, default=0): vol.Range(min=0, max=1),
+        },
+        func="async_service_ptz_location",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVIZE_PTZ_MOVE,
+        entity_domain=CAMERA_DOMAIN,
+        schema={
+            vol.Required(ATTR_PTZ_OPERATION, default=0): vol.In(list(PTZ_OPERATIONS)),
+            vol.Required(ATTR_PTZ_DURATION, default=1000): vol.Range(
+                min=100, max=10000
+            ),
+        },
+        func="async_service_ptz_move",
+    )
     return True
 
 
@@ -203,7 +241,11 @@ def _configure_device_options(device: ImouDevice, entry: ConfigEntry):
 
 
 def _cleanup_orphan_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Remove devices whose config entry no longer exists."""
+    """Remove orphan Imou devices whose config entry no longer exists.
+
+    Uses DeviceEntry.config_entry_id (HA 2026.8 single-owner model) when
+    present; falls back to this integration's (DOMAIN, entry_id) identifiers.
+    """
     try:
         device_registry = dr.async_get(hass)
         active_entry_ids = {
@@ -219,7 +261,14 @@ def _cleanup_orphan_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
             if not imou_ids:
                 continue
 
-            if not any(eid in active_entry_ids for eid in imou_ids):
+            # Prefer config_entry_id over deprecated config_entries / identifiers
+            owner_id = getattr(device_entry, "config_entry_id", None)
+            if owner_id is not None:
+                is_orphan = owner_id not in active_entry_ids
+            else:
+                is_orphan = not any(eid in active_entry_ids for eid in imou_ids)
+
+            if is_orphan:
                 _LOGGER.info(
                     "Removing orphan device '%s' (no matching config entry)",
                     device_entry.name,
@@ -526,8 +575,22 @@ async def async_remove_config_entry_device(
         config_entry.entry_id,
     )
 
-    # Check if this device belongs to this config entry by comparing identifiers
+    # Prefer config_entry_id (HA 2026.8 single-owner); fall back to identifiers
     # Note: Entities use config_entry.entry_id as the device identifier, not device_id
+    owner_id = getattr(device_entry, "config_entry_id", None)
+    if owner_id is not None:
+        if owner_id == config_entry.entry_id:
+            _LOGGER.debug(
+                "Device '%s' belongs to this config entry, allowing removal",
+                device_name,
+            )
+            return True
+        _LOGGER.debug(
+            "Device does not belong to config entry %s, preventing removal",
+            config_entry.entry_id,
+        )
+        return False
+
     for identifier in device_entry.identifiers:
         if identifier[0] == DOMAIN and identifier[1] == config_entry.entry_id:
             _LOGGER.debug(
@@ -536,7 +599,6 @@ async def async_remove_config_entry_device(
             )
             return True
 
-    # If the device doesn't match this config entry, don't allow removal
     _LOGGER.debug(
         "Device does not belong to config entry %s, preventing removal",
         config_entry.entry_id,

--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -9,7 +9,6 @@ import logging
 
 import voluptuous as vol
 from homeassistant.components import persistent_notification
-from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
@@ -56,6 +55,9 @@ from .coordinator import (
 )
 from .helpers import exception_message
 from .rate_limit_manager import RateLimitManager
+
+# String domain avoids importing homeassistant.components.camera (turbojpeg).
+CAMERA_DOMAIN = "camera"
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 

--- a/custom_components/imou_life/battery_binary_sensor.py
+++ b/custom_components/imou_life/battery_binary_sensor.py
@@ -3,17 +3,20 @@
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .battery_entity import ImouBatteryEntity
+from .coordinator import ImouConfigEntry
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
+# Serialize entity updates to prevent API rate limiting
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant, entry: ImouConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Imou battery optimization binary sensor platform."""
     coordinator = entry.runtime_data

--- a/custom_components/imou_life/battery_button.py
+++ b/custom_components/imou_life/battery_button.py
@@ -3,7 +3,6 @@
 import logging
 
 from homeassistant.components.button import ButtonEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,12 +18,16 @@ from .const import (
     DEFAULT_RECORDING_QUALITY,
     DOMAIN,
 )
+from .coordinator import ImouConfigEntry
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
+# Serialize entity updates to prevent API rate limiting
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant, entry: ImouConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Imou battery optimization button platform."""
     coordinator = entry.runtime_data

--- a/custom_components/imou_life/battery_entity.py
+++ b/custom_components/imou_life/battery_entity.py
@@ -3,7 +3,6 @@
 import logging
 from typing import TYPE_CHECKING
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -12,6 +11,7 @@ from .helpers import camel_to_snake
 
 if TYPE_CHECKING:
     from .battery_coordinator import BatteryOptimizationCoordinator
+    from .coordinator import ImouConfigEntry
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -24,7 +24,7 @@ class ImouBatteryEntity(CoordinatorEntity):
     def __init__(
         self,
         coordinator: "BatteryOptimizationCoordinator",
-        config_entry: ConfigEntry,
+        config_entry: "ImouConfigEntry",
         entity_type: str,
         description: str,
         unique_id_suffix: str,

--- a/custom_components/imou_life/battery_select.py
+++ b/custom_components/imou_life/battery_select.py
@@ -4,7 +4,6 @@ import logging
 from typing import Optional
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -17,12 +16,16 @@ from .const import (
     RECORDING_QUALITY_OPTIONS,
     SLEEP_SCHEDULE_OPTIONS,
 )
+from .coordinator import ImouConfigEntry
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
+# Serialize entity updates to prevent API rate limiting
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant, entry: ImouConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Imou battery optimization select platform."""
     coordinator = entry.runtime_data

--- a/custom_components/imou_life/camera.py
+++ b/custom_components/imou_life/camera.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import Callable
 
 import imouapi
-import voluptuous as vol
 from homeassistant.components.camera import (
     ENTITY_ID_FORMAT,
     Camera,
@@ -13,21 +12,9 @@ from homeassistant.components.camera import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_platform
-from imouapi.const import PTZ_OPERATIONS
 from imouapi.exceptions import ImouException
 
-from .const import (
-    ATTR_PTZ_DURATION,
-    ATTR_PTZ_HORIZONTAL,
-    ATTR_PTZ_OPERATION,
-    ATTR_PTZ_VERTICAL,
-    ATTR_PTZ_ZOOM,
-    DOMAIN,
-    ENABLED_CAMERAS,
-    SERVIZE_PTZ_LOCATION,
-    SERVIZE_PTZ_MOVE,
-)
+from .const import DOMAIN, ENABLED_CAMERAS
 from .helpers import camel_to_snake
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -37,36 +24,14 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 PARALLEL_UPDATES = 1
 
 
-# async def async_setup_entry(hass, entry, async_add_devices):
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_devices: Callable
 ):
-    """Configure platform."""
-    platform = entity_platform.async_get_current_platform()
+    """Configure platform.
 
-    # Create PTZ location service
-    platform.async_register_entity_service(
-        SERVIZE_PTZ_LOCATION,
-        {
-            vol.Required(ATTR_PTZ_HORIZONTAL, default=0): vol.Range(min=-1, max=1),
-            vol.Required(ATTR_PTZ_VERTICAL, default=0): vol.Range(min=-1, max=1),
-            vol.Required(ATTR_PTZ_ZOOM, default=0): vol.Range(min=0, max=1),
-        },
-        "async_service_ptz_location",
-    )
-
-    # Create PTZ move service
-    platform.async_register_entity_service(
-        SERVIZE_PTZ_MOVE,
-        {
-            vol.Required(ATTR_PTZ_OPERATION, default=0): vol.In(list(PTZ_OPERATIONS)),
-            vol.Required(ATTR_PTZ_DURATION, default=1000): vol.Range(
-                min=100, max=10000
-            ),
-        },
-        "async_service_ptz_move",
-    )
-
+    PTZ entity services are registered in the integration's async_setup via
+    service.async_register_platform_entity_service (not here).
+    """
     coordinator = entry.runtime_data
     device = coordinator.device
     sensors = []

--- a/custom_components/imou_life/camera.py
+++ b/custom_components/imou_life/camera.py
@@ -10,7 +10,6 @@ from homeassistant.components.camera import (
     Camera,
     CameraEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
@@ -28,6 +27,7 @@ from .const import (
     SERVIZE_PTZ_LOCATION,
     SERVIZE_PTZ_MOVE,
 )
+from .coordinator import ImouConfigEntry
 from .helpers import camel_to_snake
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -39,7 +39,7 @@ PARALLEL_UPDATES = 1
 
 # async def async_setup_entry(hass, entry, async_add_devices):
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_devices: Callable
+    hass: HomeAssistant, entry: ImouConfigEntry, async_add_devices: Callable
 ):
     """Configure platform."""
     platform = entity_platform.async_get_current_platform()

--- a/custom_components/imou_life/coordinator.py
+++ b/custom_components/imou_life/coordinator.py
@@ -1,8 +1,12 @@
 """Class to manage fetching data from the API."""
 
+from __future__ import annotations
+
 import logging
 from datetime import datetime, timedelta
+from typing import TypeAlias
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -247,6 +251,10 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator):
                 "Restored original scan interval to %ds (rate limit cleared)",
                 self._original_scan_interval,
             )
+
+
+# Typed config entry used across the integration (runtime_data = coordinator)
+ImouConfigEntry: TypeAlias = ConfigEntry[ImouDataUpdateCoordinator]
 
 
 class ImouDiscoveryCoordinator(DataUpdateCoordinator):

--- a/custom_components/imou_life/coordinator.py
+++ b/custom_components/imou_life/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
-from typing import TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -253,8 +253,12 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator):
             )
 
 
-# Typed config entry used across the integration (runtime_data = coordinator)
-ImouConfigEntry: TypeAlias = ConfigEntry[ImouDataUpdateCoordinator]
+# Runtime-safe alias: ConfigEntry was not subscriptable on older HA cores
+# (Quick Tests still install homeassistant>=2024.3.3 on Python 3.11).
+if TYPE_CHECKING:
+    ImouConfigEntry: TypeAlias = ConfigEntry[ImouDataUpdateCoordinator]
+else:
+    ImouConfigEntry = ConfigEntry
 
 
 class ImouDiscoveryCoordinator(DataUpdateCoordinator):

--- a/custom_components/imou_life/diagnostics.py
+++ b/custom_components/imou_life/diagnostics.py
@@ -3,14 +3,13 @@
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .coordinator import ImouDataUpdateCoordinator
+from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: ImouConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator: ImouDataUpdateCoordinator = entry.runtime_data

--- a/custom_components/imou_life/entity.py
+++ b/custom_components/imou_life/entity.py
@@ -11,9 +11,7 @@ from .const import DOMAIN
 from .helpers import camel_to_snake
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
-
-    from .coordinator import ImouDataUpdateCoordinator
+    from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -27,7 +25,7 @@ class ImouEntity(CoordinatorEntity):
     def __init__(
         self,
         coordinator: "ImouDataUpdateCoordinator",
-        config_entry: "ConfigEntry",
+        config_entry: "ImouConfigEntry",
         sensor_instance: Any,  # Type from external imouapi library
         entity_format: str,
     ) -> None:

--- a/custom_components/imou_life/manifest.json
+++ b/custom_components/imou_life/manifest.json
@@ -8,6 +8,7 @@
     "config_flow": true,
     "dependencies": [],
     "documentation": "https://github.com/maximunited/imou_life",
+    "integration_type": "device",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/maximunited/imou_life/issues",
     "quality_scale": "platinum",

--- a/custom_components/imou_life/platform_setup.py
+++ b/custom_components/imou_life/platform_setup.py
@@ -1,12 +1,14 @@
 """Common platform setup utilities for Imou integration."""
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable
 from typing import Type
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .coordinator import ImouConfigEntry
 from .entity import ImouEntity
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -14,7 +16,7 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 async def setup_platform(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ImouConfigEntry,
     platform_name: str,
     entity_class: Type[ImouEntity],
     entity_id_format: str,

--- a/custom_components/imou_life/quality_scale.yaml
+++ b/custom_components/imou_life/quality_scale.yaml
@@ -3,10 +3,10 @@
 # https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/
 
 rules:
-  # 🥉 Bronze Tier (19 rules) - Baseline quality
+  # Bronze Tier (19 rules) - Baseline quality
   action-setup: done  # PTZ services registered in camera platform
   appropriate-polling: done  # 15min default, configurable
-  brands: done  # icon.png (256×256) and icon@2x.png (512×512) from HA brands repo
+  brands: done  # icon.png (256x256) and icon@2x.png (512x512) from HA brands repo
   common-modules: done  # entity.py, entity_mixins.py, platform_setup.py
   config-flow-test-coverage: done  # 10/10 tests passing
   config-flow: done  # UI-based setup
@@ -18,27 +18,27 @@ rules:
   entity-event-setup: done  # Motion is binary_sensor (state), lastAlarm is timestamp (historical)
   entity-unique-id: done  # Using device IDs
   has-entity-name: done  # Implemented _attr_has_entity_name = True in base entity
-  runtime-data: done  # Migrated from hass.data[DOMAIN] to entry.runtime_data
+  runtime-data: done  # entry.runtime_data + typed ImouConfigEntry alias
   test-before-configure: done  # Validates credentials in config flow
   test-before-setup: done  # Validates device initialization
   unique-config-entry: done  # Uses device_id as unique_id
 
-  # 🥈 Silver Tier (10 rules) - Stable user experience
-  action-exceptions: todo  # Service exception handling needs verification
+  # Silver Tier (10 rules) - Stable user experience
+  action-exceptions: todo  # PTZ/battery wrap ImouException; select/button/siren/switch turn_* do not
   config-entry-unloading: done  # async_unload_entry implemented
   docs-configuration-parameters: done  # docs/CONFIGURATION.md
   docs-installation-parameters: done  # docs/INSTALLATION.md
   entity-unavailable: done  # Sets unavailable when offline
   integration-owner: done  # CODEOWNERS file
-  log-when-unavailable: todo  # Logging needs verification
-  parallel-updates: todo  # Not specified in platforms
-  reauthentication-flow: todo  # Not implemented
-  test-coverage: todo  # ~70% currently, need 95%
+  log-when-unavailable: done  # Coordinator raises UpdateFailed (built-in once log); entity tracks transitions
+  parallel-updates: done  # PARALLEL_UPDATES = 1 on all platforms including battery_*
+  reauthentication-flow: done  # async_step_reauth / async_step_reauth_confirm in config_flow.py
+  test-coverage: todo  # Need verified >=95%; do not claim without fresh coverage run
 
-  # 🥇 Gold Tier (23 rules) - Comprehensive support
+  # Gold Tier (23 rules) - Comprehensive support
   devices: done  # Creates devices
   diagnostics: done  # diagnostics.py implemented
-  discovery-update-info: todo  # Needs verification
+  discovery-update-info: exempt  # Cloud OpenAPI; no local host/IP from network discovery to update
   discovery: done  # Device discovery in config flow
   docs-data-update: todo  # Needs documentation
   docs-examples: todo  # No automation examples yet
@@ -47,24 +47,29 @@ rules:
   docs-supported-functions: todo  # Needs comprehensive entity documentation
   docs-troubleshooting: done  # docs/PERFORMANCE_TROUBLESHOOTING.md
   docs-use-cases: todo  # No use case examples
-  dynamic-devices: todo  # Cannot add devices after setup
+  dynamic-devices: exempt  # One device per config entry; new devices via new entries/discovery
   entity-category: done  # API status sensor uses diagnostic category
-  entity-device-class: todo  # Needs verification
-  entity-disabled-by-default: todo  # Needs verification
+  entity-device-class: todo  # Partial (motion/battery/restart/timestamp); not audited for all sensors
+  entity-disabled-by-default: done  # Diagnostic API status + advanced buttons disabled by default
   entity-translations: done  # 8 languages supported
-  exception-translations: todo  # Needs verification
+  exception-translations: done  # translations/*/exceptions + translation_key on HomeAssistantError raises
   icon-translations: done  # icons.json added
-  reconfiguration-flow: todo  # Not implemented
-  repair-issues: todo  # No repair flows
-  stale-devices: todo  # No stale device cleanup
+  reconfiguration-flow: done  # async_step_reconfigure / async_step_reconfigure_confirm
+  repair-issues: done  # async_step_repair_stale_device + _create_stale_device_repair_issue
+  stale-devices: done  # Stale detection in coordinator + repair flow / orphan cleanup
 
-  # 🏆 Platinum Tier (3 rules) - Technical excellence
+  # Platinum Tier (3 rules) - Technical excellence
   async-dependency: exempt  # imouapi library is synchronous, cannot fix without new library
   inject-websession: exempt  # imouapi doesn't accept websession, library limitation
-  strict-typing: todo  # Have type hints but not strict mode
+  strict-typing: todo  # Type hints present; mypy --strict not enabled
 
 # Exemption Notes:
 # - async-dependency: The imouapi library (1.0.15) is synchronous. Migration to async would
 #   require either switching to pyimouapi (different API) or wrapping all calls.
 # - inject-websession: imouapi library doesn't support passing aiohttp ClientSession.
 #   This is a library limitation that cannot be fixed in the integration code.
+# - discovery-update-info: Integration talks to Imou cloud OpenAPI, not LAN hosts; there is
+#   no CONF_HOST/IP to refresh from dhcp/ssdp/zeroconf discovery.
+# - dynamic-devices: Architecture is one Imou device per config entry. Additional devices
+#   are added by creating another config entry (discovery or manual), not by expanding
+#   entities under an existing entry.

--- a/custom_components/imou_life/switch.py
+++ b/custom_components/imou_life/switch.py
@@ -4,11 +4,11 @@ import logging
 from collections.abc import Callable
 
 from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN, ENABLED_SWITCHES, OPTION_CALLBACK_URL
+from .coordinator import ImouConfigEntry
 from .entity import ImouEntity
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -18,7 +18,7 @@ PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_devices: Callable
+    hass: HomeAssistant, entry: ImouConfigEntry, async_add_devices: Callable
 ):
     """Configure platform."""
     _LOGGER.debug("Setting up switch platform for entry %s", entry.entry_id)

--- a/docs/QUALITY_SCALE.md
+++ b/docs/QUALITY_SCALE.md
@@ -52,7 +52,7 @@ The Platinum tier represents the pinnacle of integration quality, achieving tech
 ## 🔍 Quality Assessment Details
 
 ### Code Quality
-- **Python Version**: 3.9+ compatibility
+- **Python Version**: 3.11+ compatibility
 - **Type Hints**: Comprehensive type annotations
 - **Code Style**: Black formatting, flake8 linting, isort imports
 - **Pre-commit Hooks**: Automated code quality checks

--- a/docs/VERSION_COMPATIBILITY.md
+++ b/docs/VERSION_COMPATIBILITY.md
@@ -21,17 +21,17 @@ Python and Home Assistant version support for the Imou Life integration.
 
 | Home Assistant | Role | Python in CI | Status |
 | -------------- | ---- | ------------ | ------ |
-| 2025.10.0 | Minimum (HACS / matrix floor) | 3.13 | Supported |
+| 2025.10.4 | Minimum (HACS / matrix floor) | 3.13 | Supported |
 | 2025.12.5 | Late previous-year pin | 3.13 | Supported |
-| 2026.8.1 | Latest stable | 3.13 | Supported |
+| 2026.8.1 | Latest stable | 3.14 | Supported |
 | `dev` | Development / nightly | 3.14 | Allowed to fail in CI |
 
 ### Requirements
 
-- **Minimum**: Home Assistant 2025.10.0 (same as `hacs.json` and the compatibility workflow)
+- **Minimum**: Home Assistant 2025.10.4 (same as `hacs.json` and the compatibility workflow)
 - **Recommended**: Latest stable (currently 2026.8.x)
-- **Python 3.13**: Requires Home Assistant 2024.12.0 or later
-- **Python 3.14**: Prefer current stable or `dev`; covered by the allow-failure matrix job
+- **Python 3.13**: Requires Home Assistant 2024.12.0 or later; HA 2026.3+ needs Python 3.14.2+
+- **Python 3.14**: Required for Home Assistant 2026.3+ (including 2026.8.x); also covered by the allow-failure `dev` job
 
 ## Compatibility Matrix
 
@@ -55,9 +55,9 @@ The `.github/workflows/ha-compatibility.yml` matrix runs:
 
 | Label | HA version | Python |
 | ----- | ---------- | ------ |
-| Minimum | 2025.10.0 | 3.13 |
+| Minimum | 2025.10.4 | 3.13 |
 | Late 2025 | 2025.12.5 | 3.13 |
-| Latest Stable | 2026.8.1 | 3.13 |
+| Latest Stable | 2026.8.1 | 3.14 |
 | Development | `dev` | 3.14 (allow-failure) |
 
 Separate unit CI also exercises Python 3.11–3.14.
@@ -77,13 +77,14 @@ Separate unit CI also exercises Python 3.11–3.14.
 ### Minimum viable
 
 - **Python**: 3.13 (3.11–3.12 still accepted by project tooling)
-- **Home Assistant**: 2025.10.0 or later
+- **Home Assistant**: 2025.10.4 or later
 
 ## Notes
 
 1. Python 3.10 and below are not supported.
-2. Home Assistant below 2025.10.0 is outside the declared support floor (HACS and CI).
+2. Home Assistant below 2025.10.4 is outside the declared support floor (HACS and CI).
 3. Python 3.13 with Home Assistant older than 2024.12.0 is not supported by Home Assistant itself.
+4. Home Assistant 2026.3+ requires Python 3.14.2+.
 
 ## Troubleshooting
 
@@ -92,7 +93,7 @@ python --version
 # Expect 3.11, 3.12, 3.13, or 3.14
 ```
 
-In Home Assistant: **Settings → About** (or Configuration → Info) and confirm Core is 2025.10.0 or later.
+In Home Assistant: **Settings → About** (or Configuration → Info) and confirm Core is 2025.10.4 or later.
 
 When opening an issue, include Python version, Home Assistant Core version, and integration version.
 

--- a/docs/VERSION_COMPATIBILITY.md
+++ b/docs/VERSION_COMPATIBILITY.md
@@ -6,9 +6,9 @@ Python and Home Assistant version support for the Imou Life integration.
 
 | Python Version | Support Status | Notes |
 | -------------- | -------------- | ----- |
-| 3.11 | Supported | Minimum for local tooling / older HA cores |
-| 3.12 | Supported | Used by CI minimum HA pin |
-| 3.13 | Supported | Recommended with current HA stable |
+| 3.11 | Supported | Minimum for local tooling |
+| 3.12 | Supported | Supported with current HA floor |
+| 3.13 | Supported | Recommended with current HA stable; used by CI matrix |
 | 3.14 | Supported in CI | Covered by unit CI and HA `dev` matrix job |
 
 ### Requirements
@@ -21,32 +21,32 @@ Python and Home Assistant version support for the Imou Life integration.
 
 | Home Assistant | Role | Python in CI | Status |
 | -------------- | ---- | ------------ | ------ |
-| 2024.12.5 | Minimum (HACS / matrix floor) | 3.12 | Supported |
+| 2025.10.0 | Minimum (HACS / matrix floor) | 3.13 | Supported |
 | 2025.12.5 | Late previous-year pin | 3.13 | Supported |
 | 2026.8.1 | Latest stable | 3.13 | Supported |
 | `dev` | Development / nightly | 3.14 | Allowed to fail in CI |
 
 ### Requirements
 
-- **Minimum**: Home Assistant 2024.12.5 (same as `hacs.json` and the compatibility workflow)
+- **Minimum**: Home Assistant 2025.10.0 (same as `hacs.json` and the compatibility workflow)
 - **Recommended**: Latest stable (currently 2026.8.x)
 - **Python 3.13**: Requires Home Assistant 2024.12.0 or later
 - **Python 3.14**: Prefer current stable or `dev`; covered by the allow-failure matrix job
 
 ## Compatibility Matrix
 
-| Python | HA 2024.12+ | HA 2025.12+ | HA 2026.8+ | HA `dev` |
+| Python | HA 2025.10+ | HA 2025.12+ | HA 2026.8+ | HA `dev` |
 | ------ | ----------- | ----------- | ---------- | -------- |
 | 3.11 | Supported | Supported | Supported | Best-effort |
-| 3.12 | Supported (CI min pin) | Supported | Supported | Best-effort |
-| 3.13 | Supported | Supported (CI late-2025 pin) | Supported (CI latest stable) | Best-effort |
+| 3.12 | Supported | Supported | Supported | Best-effort |
+| 3.13 | Supported (CI min pin) | Supported (CI late-2025 pin) | Supported (CI latest stable) | Best-effort |
 | 3.14 | Best-effort | Best-effort | Best-effort | CI allow-failure |
 
 ### Why this floor?
 
-1. **2024.12.x**: First Home Assistant line with Python 3.13 support; a practical minimum without jumping straight to 2025/2026.
-2. **2025.12.x**: Keeps a late previous-year pin in CI so regressions are not only caught on bleeding-edge or ancient cores.
-3. **2026.8.x**: Current stable line validated in CI.
+1. **2025.10.x**: Required for `service.async_register_platform_entity_service` used to register PTZ camera entity services from integration `async_setup`.
+2. **2025.12.x**: Keeps a late previous-year pin in CI so regressions are not only caught on bleeding-edge cores.
+3. **2026.8.x**: Current stable line validated in CI (including device-registry single-owner APIs with shims).
 4. **`dev` + Python 3.14**: Early warning for upcoming HA / Python breakage; failures do not block merges.
 
 ## Testing
@@ -55,7 +55,7 @@ The `.github/workflows/ha-compatibility.yml` matrix runs:
 
 | Label | HA version | Python |
 | ----- | ---------- | ------ |
-| Minimum | 2024.12.5 | 3.12 |
+| Minimum | 2025.10.0 | 3.13 |
 | Late 2025 | 2025.12.5 | 3.13 |
 | Latest Stable | 2026.8.1 | 3.13 |
 | Development | `dev` | 3.14 (allow-failure) |
@@ -76,13 +76,13 @@ Separate unit CI also exercises Python 3.11–3.14.
 
 ### Minimum viable
 
-- **Python**: 3.12 (3.11 still accepted by project tooling)
-- **Home Assistant**: 2024.12.5 or later
+- **Python**: 3.13 (3.11–3.12 still accepted by project tooling)
+- **Home Assistant**: 2025.10.0 or later
 
 ## Notes
 
 1. Python 3.10 and below are not supported.
-2. Home Assistant below 2024.12.5 is outside the declared support floor (HACS and CI).
+2. Home Assistant below 2025.10.0 is outside the declared support floor (HACS and CI).
 3. Python 3.13 with Home Assistant older than 2024.12.0 is not supported by Home Assistant itself.
 
 ## Troubleshooting
@@ -92,7 +92,7 @@ python --version
 # Expect 3.11, 3.12, 3.13, or 3.14
 ```
 
-In Home Assistant: **Settings → About** (or Configuration → Info) and confirm Core is 2024.12.5 or later.
+In Home Assistant: **Settings → About** (or Configuration → Info) and confirm Core is 2025.10.0 or later.
 
 When opening an issue, include Python version, Home Assistant Core version, and integration version.
 

--- a/docs/VERSION_COMPATIBILITY.md
+++ b/docs/VERSION_COMPATIBILITY.md
@@ -1,152 +1,109 @@
 # Version Compatibility Guide
 
-This document provides comprehensive information about Python and Home Assistant version compatibility for the Imou Life integration.
+Python and Home Assistant version support for the Imou Life integration.
 
-## 🐍 Python Version Support
+## Python Version Support
 
-### Supported Python Versions
+| Python Version | Support Status | Notes |
+| -------------- | -------------- | ----- |
+| 3.11 | Supported | Minimum for local tooling / older HA cores |
+| 3.12 | Supported | Used by CI minimum HA pin |
+| 3.13 | Supported | Recommended with current HA stable |
+| 3.14 | Supported in CI | Covered by unit CI and HA `dev` matrix job |
 
-| Python Version | Release Date | Support Status | Notes |
-|----------------|---------------|----------------|-------|
-| **3.11** | October 2022 | ✅ **Fully Supported** | Stable, recommended for production |
-| **3.12** | October 2023 | ✅ **Fully Supported** | Latest stable, recommended for new deployments |
-| **3.13** | October 2024 | ✅ **Fully Supported** | Latest development, fully tested |
-
-### Python Version Requirements
+### Requirements
 
 - **Minimum**: Python 3.11
-- **Recommended**: Python 3.12 or 3.13
-- **Maximum**: Python 3.13 (latest available)
+- **Recommended**: Python 3.13 with current Home Assistant stable
+- **CI coverage**: 3.11–3.14
 
-## 🏠 Home Assistant Version Support
+## Home Assistant Version Support
 
-### Supported Home Assistant Versions
+| Home Assistant | Role | Python in CI | Status |
+| -------------- | ---- | ------------ | ------ |
+| 2024.12.5 | Minimum (HACS / matrix floor) | 3.12 | Supported |
+| 2025.12.5 | Late previous-year pin | 3.13 | Supported |
+| 2026.8.1 | Latest stable | 3.13 | Supported |
+| `dev` | Development / nightly | 3.14 | Allowed to fail in CI |
 
-| Home Assistant Version | Release Date | Python Support | Integration Status |
-|------------------------|--------------|----------------|-------------------|
-| **2024.2.0** | February 2024 | 3.11, 3.12 | ✅ **Minimum Required** |
-| **2024.12.0** | December 2024 | 3.11, 3.12, 3.13 | ✅ **Python 3.13 Support Added** |
-| **2025.1.0** | January 2025 | 3.11, 3.12, 3.13 | ✅ **Latest Stable** |
-| **2025.8.3+** | August 2025 | 3.11, 3.12, 3.13 | ✅ **Latest Development** |
+### Requirements
 
-### Home Assistant Requirements
+- **Minimum**: Home Assistant 2024.12.5 (same as `hacs.json` and the compatibility workflow)
+- **Recommended**: Latest stable (currently 2026.8.x)
+- **Python 3.13**: Requires Home Assistant 2024.12.0 or later
+- **Python 3.14**: Prefer current stable or `dev`; covered by the allow-failure matrix job
 
-- **Minimum**: 2024.2.0
-- **Recommended**: Latest stable release
-- **Python 3.13**: Requires 2024.12.0 or later
+## Compatibility Matrix
 
-## 🔄 Compatibility Matrix
+| Python | HA 2024.12+ | HA 2025.12+ | HA 2026.8+ | HA `dev` |
+| ------ | ----------- | ----------- | ---------- | -------- |
+| 3.11 | Supported | Supported | Supported | Best-effort |
+| 3.12 | Supported (CI min pin) | Supported | Supported | Best-effort |
+| 3.13 | Supported | Supported (CI late-2025 pin) | Supported (CI latest stable) | Best-effort |
+| 3.14 | Best-effort | Best-effort | Best-effort | CI allow-failure |
 
-### Full Compatibility Matrix
+### Why this floor?
 
-| Python | HA 2024.2+ | HA 2024.12+ | HA 2025.1+ | HA 2025.8+ |
-|--------|-------------|--------------|-------------|-------------|
-| **3.11** | ✅ **Full** | ✅ **Full** | ✅ **Full** | ✅ **Full** |
-| **3.12** | ✅ **Full** | ✅ **Full** | ✅ **Full** | ✅ **Full** |
-| **3.13** | ❌ **No** | ✅ **Full** | ✅ **Full** | ✅ **Full** |
+1. **2024.12.x**: First Home Assistant line with Python 3.13 support; a practical minimum without jumping straight to 2025/2026.
+2. **2025.12.x**: Keeps a late previous-year pin in CI so regressions are not only caught on bleeding-edge or ancient cores.
+3. **2026.8.x**: Current stable line validated in CI.
+4. **`dev` + Python 3.14**: Early warning for upcoming HA / Python breakage; failures do not block merges.
 
-### Why This Version Range?
+## Testing
 
-1. **Home Assistant 2024.2.0**: First version with comprehensive Python 3.11-3.12 support
-2. **Home Assistant 2024.12.0**: First version with Python 3.13 support
-3. **Future Versions**: All future Home Assistant versions will be compatible
+The `.github/workflows/ha-compatibility.yml` matrix runs:
 
-## 🧪 Testing & Validation
+| Label | HA version | Python |
+| ----- | ---------- | ------ |
+| Minimum | 2024.12.5 | 3.12 |
+| Late 2025 | 2025.12.5 | 3.13 |
+| Latest Stable | 2026.8.1 | 3.13 |
+| Development | `dev` | 3.14 (allow-failure) |
 
-### CI/CD Testing
+Separate unit CI also exercises Python 3.11–3.14.
 
-Our GitHub Actions workflow tests all supported combinations:
+## Installation recommendations
 
-- **Python 3.11** + Home Assistant 2024.2.0+
-- **Python 3.12** + Home Assistant 2024.2.0+
-- **Python 3.13** + Home Assistant 2024.12.0+
+### Production
 
-### Test Coverage
+- **Python**: 3.13
+- **Home Assistant**: Latest stable (2026.8.x or newer)
 
-- **Unit Tests**: ✅ All Python versions
-- **Integration Tests**: ✅ All Python versions
-- **Home Assistant Integration**: ✅ All supported versions
-- **Code Quality**: ✅ Linting, formatting, security checks
+### Development
 
-## 🚀 Installation Recommendations
+- **Python**: 3.13 or 3.14
+- **Home Assistant**: Latest stable, plus occasional `dev` checks
 
-### For Production Use
+### Minimum viable
 
-**Recommended Configuration:**
-- **Python**: 3.12 (stable, well-tested)
-- **Home Assistant**: Latest stable release
-- **Platform**: Any supported platform
+- **Python**: 3.12 (3.11 still accepted by project tooling)
+- **Home Assistant**: 2024.12.5 or later
 
-### For Development
+## Notes
 
-**Development Environment:**
-- **Python**: 3.13 (latest features)
-- **Home Assistant**: Latest development release
-- **Platform**: Linux/macOS recommended for full testing
+1. Python 3.10 and below are not supported.
+2. Home Assistant below 2024.12.5 is outside the declared support floor (HACS and CI).
+3. Python 3.13 with Home Assistant older than 2024.12.0 is not supported by Home Assistant itself.
 
-### For Legacy Systems
+## Troubleshooting
 
-**Minimum Viable Configuration:**
-- **Python**: 3.11
-- **Home Assistant**: 2024.2.0
-- **Platform**: Any supported platform
-
-## ⚠️ Important Notes
-
-### Version Constraints
-
-1. **Python 3.10 and below**: Not supported (Home Assistant compatibility)
-2. **Home Assistant below 2024.2.0**: Not supported (API compatibility)
-3. **Python 3.13 with HA < 2024.12.0**: Not supported (HA doesn't support Python 3.13)
-
-### Migration Paths
-
-- **From Python 3.10**: Upgrade to Python 3.11+ and HA 2024.2.0+
-- **From HA < 2024.2.0**: Upgrade to HA 2024.2.0+ (Python 3.11+)
-- **To Python 3.13**: Ensure HA 2024.12.0+ is installed
-
-## 🔧 Troubleshooting
-
-### Common Compatibility Issues
-
-#### Python Version Issues
 ```bash
-# Check Python version
 python --version
-
-# Should show 3.11, 3.12, or 3.13
+# Expect 3.11, 3.12, 3.13, or 3.14
 ```
 
-#### Home Assistant Version Issues
-```yaml
-# In Home Assistant, check version
-# Configuration → Info → Home Assistant Core
-# Should show 2024.2.0 or later
-```
+In Home Assistant: **Settings → About** (or Configuration → Info) and confirm Core is 2024.12.5 or later.
 
-#### Integration Installation Issues
-```bash
-# If using manual installation, ensure Python version compatibility
-python -c "import sys; print(f'Python {sys.version_info.major}.{sys.version_info.minor}')"
-```
+When opening an issue, include Python version, Home Assistant Core version, and integration version.
 
-### Getting Help
+## Additional resources
 
-If you encounter compatibility issues:
-
-1. **Check your versions**: Python and Home Assistant
-2. **Verify requirements**: Ensure minimum versions are met
-3. **Check logs**: Look for version-related error messages
-4. **Open an issue**: Include version information in your report
-
-## 📚 Additional Resources
-
-- **[Home Assistant Python Support](https://developers.home-assistant.io/docs/core/architecture/python-version-support/)**
-- **[Python Version Support Matrix](https://www.python.org/downloads/)**
-- **[Home Assistant Release Notes](https://www.home-assistant.io/blog/categories/release-notes/)**
+- [Home Assistant Python support](https://developers.home-assistant.io/docs/core/architecture/python-version-support/)
+- [Python downloads](https://www.python.org/downloads/)
+- [Home Assistant release notes](https://www.home-assistant.io/blog/categories/release-notes/)
 
 ---
 
-**Last Updated**: August 2025
-**Integration Version**: 1.1.1
+**Last Updated**: August 2026
+**Integration Version**: 1.8.5 (`pyproject.toml`; keep in sync with releases)
 **Maintainer**: [@maximunited](https://github.com/maximunited)

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Imou Life",
   "render_readme": true,
-  "homeassistant": "2024.12.5",
+  "homeassistant": "2025.10.0",
   "zip_release": true,
   "filename": "imou_life.zip",
   "hide_default_branch": true,

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Imou Life",
   "render_readme": true,
-  "homeassistant": "2025.10.0",
+  "homeassistant": "2025.10.4",
   "zip_release": true,
   "filename": "imou_life.zip",
   "hide_default_branch": true,

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Imou Life",
   "render_readme": true,
-  "homeassistant": "2024.2.0",
+  "homeassistant": "2024.12.5",
   "zip_release": true,
   "filename": "imou_life.zip",
   "hide_default_branch": true,

--- a/tests/unit/test_bronze_tier_compliance.py
+++ b/tests/unit/test_bronze_tier_compliance.py
@@ -171,7 +171,8 @@ class TestBronzeTierCompliance:
     async def test_service_registration_ptz(self, hass, api_ok):
         """Test: action-setup - PTZ services are registered.
 
-        Bronze tier requires service actions to be registered in platform setup.
+        PTZ entity services are registered from integration async_setup via
+        service.async_register_platform_entity_service.
         """
         from tests.fixtures.mocks import MockConfigEntry
 

--- a/tests/unit/test_camera_comprehensive.py
+++ b/tests/unit/test_camera_comprehensive.py
@@ -1,6 +1,6 @@
 """Comprehensive tests for the Imou Life Camera platform."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
@@ -40,18 +40,10 @@ class TestCameraSetup:
         from custom_components.imou_life.camera import async_setup_entry
 
         async_add_devices = MagicMock()
-        mock_platform = MagicMock()
 
-        with patch(
-            "custom_components.imou_life.camera.entity_platform.async_get_current_platform",
-            return_value=mock_platform,
-        ):
-            await async_setup_entry(MagicMock(), mock_config_entry, async_add_devices)
+        await async_setup_entry(MagicMock(), mock_config_entry, async_add_devices)
 
-        # Should register PTZ services
-        assert mock_platform.async_register_entity_service.call_count == 2
-
-        # Should call async_add_devices with empty list
+        # PTZ services are registered in integration async_setup, not here
         async_add_devices.assert_called_once()
         added_devices = async_add_devices.call_args[0][0]
         assert len(added_devices) == 0
@@ -80,13 +72,8 @@ class TestCameraSetup:
         ]
 
         async_add_devices = MagicMock()
-        mock_platform = MagicMock()
 
-        with patch(
-            "custom_components.imou_life.camera.entity_platform.async_get_current_platform",
-            return_value=mock_platform,
-        ):
-            await async_setup_entry(MagicMock(), mock_config_entry, async_add_devices)
+        await async_setup_entry(MagicMock(), mock_config_entry, async_add_devices)
 
         # Should add 2 camera entities
         async_add_devices.assert_called_once()

--- a/tests/unit/test_device_removal.py
+++ b/tests/unit/test_device_removal.py
@@ -140,3 +140,61 @@ async def test_async_remove_config_entry_device_no_device_id(hass: HomeAssistant
     # Should return False - identifier doesn't match config_entry.entry_id
     result = await async_remove_config_entry_device(hass, config_entry, device_entry)
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_async_remove_config_entry_device_via_config_entry_id(
+    hass: HomeAssistant,
+):
+    """Test removal allowed when device.config_entry_id matches (HA 2026.8)."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "test_device_123",
+            CONF_DEVICE_NAME: "Test Camera",
+        },
+        entry_id="test_entry_id",
+        version=3,
+        title="Test Camera",
+    )
+
+    device_entry = SimpleNamespace(
+        id="device_id_123",
+        identifiers={(DOMAIN, "unrelated_id")},
+        config_entry_id="test_entry_id",
+        manufacturer="Imou",
+        model="Test Model",
+        name="Test Camera",
+    )
+
+    result = await async_remove_config_entry_device(hass, config_entry, device_entry)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_async_remove_config_entry_device_mismatched_config_entry_id(
+    hass: HomeAssistant,
+):
+    """Test removal denied when config_entry_id belongs to another entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_ID: "test_device_123",
+            CONF_DEVICE_NAME: "Test Camera",
+        },
+        entry_id="test_entry_id",
+        version=3,
+        title="Test Camera",
+    )
+
+    device_entry = SimpleNamespace(
+        id="device_id_456",
+        identifiers={(DOMAIN, "test_entry_id")},
+        config_entry_id="other_entry_id",
+        manufacturer="Imou",
+        model="Test Model",
+        name="Other Camera",
+    )
+
+    result = await async_remove_config_entry_device(hass, config_entry, device_entry)
+    assert result is False

--- a/tests/unit/test_init_comprehensive.py
+++ b/tests/unit/test_init_comprehensive.py
@@ -29,11 +29,17 @@ class TestAsyncSetup:
 
     @pytest.mark.asyncio
     async def test_async_setup_returns_true(self):
-        """Test async_setup returns True (YAML not supported)."""
+        """Test async_setup registers PTZ services and returns True."""
         hass = MagicMock()
         config = {}
-        result = await async_setup(hass, config)
+        with patch(
+            "custom_components.imou_life.service.async_register_platform_entity_service"
+        ) as mock_register:
+            result = await async_setup(hass, config)
         assert result is True
+        assert mock_register.call_count == 2
+        service_names = {call.args[2] for call in mock_register.call_args_list}
+        assert service_names == {"ptz_location", "ptz_move"}
 
 
 class TestTimeoutParsing:

--- a/tests/unit/test_init_comprehensive.py
+++ b/tests/unit/test_init_comprehensive.py
@@ -33,7 +33,8 @@ class TestAsyncSetup:
         hass = MagicMock()
         config = {}
         with patch(
-            "custom_components.imou_life.service.async_register_platform_entity_service"
+            "custom_components.imou_life.service.async_register_platform_entity_service",
+            create=True,
         ) as mock_register:
             result = await async_setup(hass, config)
         assert result is True

--- a/tests/unit/test_orphan_cleanup.py
+++ b/tests/unit/test_orphan_cleanup.py
@@ -8,14 +8,19 @@ from custom_components.imou_life.const import DOMAIN
 from tests.fixtures.mocks import MockConfigEntry
 
 
-def _make_device_entry(device_id, identifiers):
+def _make_device_entry(device_id, identifiers, config_entry_id=None):
     """Create a device-entry-like object with the given identifiers.
 
     Uses SimpleNamespace instead of the real DeviceEntry dataclass so the
     test doesn't couple to Home Assistant's constructor, which has changed
     its required fields across HA releases.
     """
-    return SimpleNamespace(id=device_id, identifiers=identifiers, name=device_id)
+    return SimpleNamespace(
+        id=device_id,
+        identifiers=identifiers,
+        name=device_id,
+        config_entry_id=config_entry_id,
+    )
 
 
 def _make_registry(device_entries):
@@ -138,3 +143,41 @@ class TestCleanupOrphanDevices:
 
         with patch("custom_components.imou_life.dr.async_get", return_value=registry):
             _cleanup_orphan_devices(hass, active_entry)
+
+    def test_removes_orphan_via_config_entry_id(self):
+        """Orphan detected via config_entry_id (HA 2026.8) is removed."""
+        orphan = _make_device_entry(
+            "dev1",
+            {(DOMAIN, "deleted_entry_id")},
+            config_entry_id="deleted_entry_id",
+        )
+        registry = _make_registry([orphan])
+
+        active_entry = MockConfigEntry(
+            domain=DOMAIN, data={}, entry_id="active_entry_id"
+        )
+        hass = _make_hass([active_entry])
+
+        with patch("custom_components.imou_life.dr.async_get", return_value=registry):
+            _cleanup_orphan_devices(hass, active_entry)
+
+        registry.async_remove_device.assert_called_once_with("dev1")
+
+    def test_keeps_device_via_config_entry_id(self):
+        """Active device kept when config_entry_id matches live entry."""
+        active_device = _make_device_entry(
+            "dev1",
+            {(DOMAIN, "active_entry_id")},
+            config_entry_id="active_entry_id",
+        )
+        registry = _make_registry([active_device])
+
+        active_entry = MockConfigEntry(
+            domain=DOMAIN, data={}, entry_id="active_entry_id"
+        )
+        hass = _make_hass([active_entry])
+
+        with patch("custom_components.imou_life.dr.async_get", return_value=registry):
+            _cleanup_orphan_devices(hass, active_entry)
+
+        registry.async_remove_device.assert_not_called()


### PR DESCRIPTION
## Summary
- Align with Home Assistant 2026.8: device registry uses `config_entry_id`, PTZ services register via `async_register_platform_entity_service`, manifest `integration_type: device`.
- Refresh CI/HACS/docs compatibility matrix (latest stable 2026.8.1); raise declared minimum to **2025.10.0** so it matches the PTZ service API.
- Reconcile `quality_scale.yaml` with implemented rules and introduce typed `ImouConfigEntry`.

## Test plan
- [x] Focused unit tests (orphan cleanup, device removal, camera, init, bronze, reauth) — 67 passed
- [ ] HA compatibility workflow on PR (2025.10.0 / 2025.12.5 / 2026.8.1 / dev)
- [ ] HACS + hassfest validation on PR
- [ ] Manual: PTZ services still listed under camera entities on HA 2025.10+
- [ ] Manual: device delete / orphan cleanup still behaves on multi-entry setups

## Reviews
- Bugbot: fixed HA floor mismatch for PTZ registration API
- Security review: no medium+ issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validated PTZ camera controls for location and movement.
  - Registered the integration as a device-based Home Assistant integration.
  - Improved device ownership handling during setup, removal, and cleanup.

- **Compatibility**
  - Added support for Home Assistant 2025.10.4–2026.8.1 and Python 3.11–3.14.
  - Raised the minimum supported Home Assistant version to 2025.10.4.

- **Documentation**
  - Updated compatibility guidance, quality-scale tracking, troubleshooting, and support recommendations.

- **Reliability**
  - Serialized platform updates to help reduce API rate-limit issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->