### PR TITLE
fix: sync manifest version with PSR and add drift guards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,11 @@ jobs:
         run: |
           pre-commit run --all-files --show-diff-on-failure --color=always
 
+      - name: Verify manifest version matches pyproject.toml
+        run: |
+          python tools/scripts/sync_version.py
+          git diff --exit-code custom_components/imou_life/manifest.json
+
   quick-tests:
     runs-on: "ubuntu-latest"
     strategy:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -90,6 +90,10 @@ jobs:
     - name: Validate manifest
       run: |
         python -c "import json; json.load(open('custom_components/imou_life/manifest.json')); print('Manifest validation passed')"
+    - name: Verify manifest version matches pyproject.toml
+      run: |
+        python tools/scripts/sync_version.py
+        git diff --exit-code custom_components/imou_life/manifest.json
     - name: Validate translations
       run: |
         python -c "import json; import glob; [json.load(open(f)) for f in glob.glob('custom_components/imou_life/translations/*.json')]; print('Translation validation passed')"

--- a/custom_components/imou_life/manifest.json
+++ b/custom_components/imou_life/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "imouapi==1.0.15"
     ],
-    "version": "1.8.5"
+    "version": "1.9.0"
 }

--- a/custom_components/imou_life/manifest.json
+++ b/custom_components/imou_life/manifest.json
@@ -15,5 +15,5 @@
     "requirements": [
         "imouapi==1.0.15"
     ],
-    "version": "1.6.0"
+    "version": "1.8.5"
 }

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -142,7 +142,8 @@ Following [Semantic Versioning](https://semver.org/):
 ## Configuration
 
 PSR is configured in `pyproject.toml` under `[tool.semantic_release]`:
-- Version is tracked in both `pyproject.toml` and `manifest.json`
+- Version is tracked in both `pyproject.toml` (`version_toml`) and `manifest.json` (`version_variables`)
+- CI runs `tools/scripts/sync_version.py` and fails if `manifest.json` drifts from `pyproject.toml`
 - **PSR does NOT update `docs/CHANGELOG.md`** — auto-generation is disabled (`changelog_file = ""`)
 - `docs/CHANGELOG.md` is maintained manually as the curated release history
 - GitHub Release notes are auto-generated from PR labels (via `.github/release.yml`)
@@ -183,8 +184,9 @@ gh workflow run "Release Artifacts" -f tag=v1.7.0
 
 ### Version mismatch between files
 
-PSR updates both `pyproject.toml` and `manifest.json`. If they're out of sync:
+PSR updates both `pyproject.toml` and `manifest.json` in the same release commit. If they're out of sync locally:
 ```bash
+python tools/scripts/sync_version.py
 semantic-release version --noop  # Check what PSR thinks the version should be
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ extend-exclude = '''
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
+version_variables = ["custom_components/imou_life/manifest.json:version"]
 tag_format = "v{version}"
 commit_message = "chore(release): bump version to {version}"
 major_on_zero = false

--- a/tests/unit/test_version_sync.py
+++ b/tests/unit/test_version_sync.py
@@ -1,0 +1,93 @@
+"""Tests for release and compatibility version drift guards."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+MANIFEST = REPO_ROOT / "custom_components/imou_life/manifest.json"
+HACS_JSON = REPO_ROOT / "hacs.json"
+HA_COMPAT_WORKFLOW = REPO_ROOT / ".github/workflows/ha-compatibility.yml"
+VERSION_COMPAT_DOC = REPO_ROOT / "docs/VERSION_COMPATIBILITY.md"
+PSR_MANIFEST_VARIABLE = "custom_components/imou_life/manifest.json:version"
+
+
+def _load_sync_version() -> ModuleType:
+    script_path = REPO_ROOT / "tools" / "scripts" / "sync_version.py"
+    spec = importlib.util.spec_from_file_location("sync_version", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load sync_version from {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module", name="sync_version")
+def fixture_sync_version() -> ModuleType:
+    return _load_sync_version()
+
+
+class TestReleaseVersionDrift:
+    """Guard against pyproject.toml and manifest.json drifting apart."""
+
+    def test_manifest_matches_pyproject(self, sync_version: ModuleType) -> None:
+        assert sync_version.read_manifest_version(
+            MANIFEST
+        ) == sync_version.read_pyproject_version(PYPROJECT)
+
+    def test_sync_version_is_idempotent(self, sync_version: ModuleType) -> None:
+        before = MANIFEST.read_text(encoding="utf-8")
+        sync_version.sync_manifest_version(PYPROJECT, MANIFEST)
+        after = MANIFEST.read_text(encoding="utf-8")
+        assert before == after
+
+    def test_sync_version_updates_drifted_manifest(
+        self, sync_version: ModuleType, tmp_path: Path
+    ) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        manifest = tmp_path / "manifest.json"
+        pyproject.write_text('[project]\nversion = "9.9.9"\n', encoding="utf-8")
+        manifest.write_text(json.dumps({"version": "1.0.0"}), encoding="utf-8")
+
+        version = sync_version.sync_manifest_version(pyproject, manifest)
+
+        assert version == "9.9.9"
+        assert json.loads(manifest.read_text(encoding="utf-8"))["version"] == "9.9.9"
+
+    def test_psr_tracks_both_version_files(self) -> None:
+        content = PYPROJECT.read_text(encoding="utf-8")
+        assert 'version_toml = ["pyproject.toml:project.version"]' in content
+        assert "version_variables" in content
+        assert PSR_MANIFEST_VARIABLE in content
+
+
+class TestHaFloorDrift:
+    """Guard against hacs.json, CI matrix, and docs disagreeing on HA floor."""
+
+    def test_hacs_homeassistant_in_ci_matrix(self) -> None:
+        hacs = json.loads(HACS_JSON.read_text(encoding="utf-8"))
+        workflow = HA_COMPAT_WORKFLOW.read_text(encoding="utf-8")
+        floor = hacs["homeassistant"]
+        assert f'ha-version: "{floor}"' in workflow
+
+    def test_hacs_homeassistant_documented(self) -> None:
+        hacs = json.loads(HACS_JSON.read_text(encoding="utf-8"))
+        doc = VERSION_COMPAT_DOC.read_text(encoding="utf-8")
+        assert hacs["homeassistant"] in doc
+
+    def test_minimum_ci_matrix_matches_hacs_floor(self) -> None:
+        hacs = json.loads(HACS_JSON.read_text(encoding="utf-8"))
+        workflow = HA_COMPAT_WORKFLOW.read_text(encoding="utf-8")
+        match = re.search(
+            r'- ha-version:\s*"([^"]+)"\s*\n\s*python-version:.*\n\s*label:\s*"Minimum"',
+            workflow,
+        )
+        assert match is not None, "Could not find labeled Minimum HA matrix cell"
+        assert match.group(1) == hacs["homeassistant"]

--- a/tools/scripts/sync_version.py
+++ b/tools/scripts/sync_version.py
@@ -1,10 +1,14 @@
 """Sync version from pyproject.toml to manifest.json.
 
-Called by python-semantic-release via build_command after version bump.
+PSR bumps manifest.json via version_variables; this script is used by
+build_command (belt-and-suspenders) and CI to verify the files stay aligned.
 """
+
+from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -14,23 +18,50 @@ else:
     except ImportError:
         import tomli as tomllib
 
-PYPROJECT = "pyproject.toml"
-MANIFEST = "custom_components/imou_life/manifest.json"
+PYPROJECT = Path("pyproject.toml")
+MANIFEST = Path("custom_components/imou_life/manifest.json")
 
 
-def main() -> None:
-    with open(PYPROJECT, "rb") as f:
-        version: str = tomllib.load(f)["project"]["version"]
+def read_pyproject_version(pyproject_path: Path | str = PYPROJECT) -> str:
+    """Return the project version from pyproject.toml."""
+    with open(pyproject_path, "rb") as file:
+        version = tomllib.load(file)["project"]["version"]
+    if not isinstance(version, str):
+        raise TypeError("pyproject.toml project.version must be a string")
+    return version
 
-    with open(MANIFEST) as f:
-        manifest: dict[str, object] = json.load(f)
+
+def read_manifest_version(manifest_path: Path | str = MANIFEST) -> str:
+    """Return the integration version from manifest.json."""
+    with open(manifest_path, encoding="utf-8") as file:
+        version = json.load(file)["version"]
+    if not isinstance(version, str):
+        raise TypeError("manifest.json version must be a string")
+    return version
+
+
+def sync_manifest_version(
+    pyproject_path: Path | str = PYPROJECT,
+    manifest_path: Path | str = MANIFEST,
+) -> str:
+    """Copy pyproject version into manifest.json and return that version."""
+    version = read_pyproject_version(pyproject_path)
+    manifest_path = Path(manifest_path)
+
+    with open(manifest_path, encoding="utf-8") as file:
+        manifest: dict[str, object] = json.load(file)
 
     manifest["version"] = version
 
-    with open(MANIFEST, "w") as f:
-        json.dump(manifest, f, indent=4)
-        f.write("\n")
+    with open(manifest_path, "w", encoding="utf-8") as file:
+        json.dump(manifest, file, indent=4)
+        file.write("\n")
 
+    return version
+
+
+def main() -> None:
+    version = sync_manifest_version()
     print(f"Synced version {version} to {MANIFEST}")
 
 


### PR DESCRIPTION
## Summary
- Add PSR `version_variables` so `manifest.json` is bumped in the same release commit as `pyproject.toml`
- Catch up `manifest.json` from 1.6.0 to 1.8.5
- Add CI checks in `test.yml` and `validate.yml` that fail if manifest drifts from pyproject
- Add `tests/unit/test_version_sync.py` with release-version and HA-floor drift guards

## Test plan
- [x] `pytest tests/unit/test_version_sync.py -v`
- [ ] CI green on Quick PR Checks
- [ ] CI green on Comprehensive Validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Updated the integration version to 1.8.5.
  * Improved version synchronization between project configuration and the integration manifest.
  * Automated validation now detects version mismatches before release.

* **Documentation**
  * Clarified version configuration, synchronization, and troubleshooting steps in the release process guide.

* **Tests**
  * Added coverage for version consistency, synchronization behavior, compatibility settings, and CI configuration alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->