### PR TITLE
feat: wrap platform actions in translated HomeAssistantError

### DIFF
--- a/custom_components/imou_life/button.py
+++ b/custom_components/imou_life/button.py
@@ -3,9 +3,13 @@
 import logging
 
 from homeassistant.components.button import ENTITY_ID_FORMAT, ButtonEntity
+from homeassistant.exceptions import HomeAssistantError
+from imouapi.exceptions import ImouException
 
+from .const import DOMAIN
 from .entity import ImouEntity
 from .entity_mixins import DeviceClassMixin
+from .helpers import exception_message
 from .platform_setup import setup_platform
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -36,26 +40,35 @@ class ImouButton(ImouEntity, ButtonEntity, DeviceClassMixin):
 
     async def async_press(self) -> None:
         """Handle the button press."""
-        # press the button
-        await self.sensor_instance.async_press()
-        _LOGGER.debug(
-            "[%s] Pressed %s",
-            self.device.get_name(),
-            self.sensor_instance.get_description(),
-        )
-        # ask the coordinator to refresh data to all the sensors
-        if self.sensor_instance.get_name() == "refreshData":
-            await self.coordinator.async_request_refresh()
-        # refresh the motionAlarm sensor
-        if self.sensor_instance.get_name() == "refreshAlarm":
-            # update the motionAlarm sensor
-            await self.coordinator.device.get_sensor_by_name(
-                "motionAlarm"
-            ).async_update()
-            # ask HA to update its state based on the new value
-            for entity in self.coordinator.entities:
-                if entity.sensor_instance.get_name() in "motionAlarm":
-                    await entity.async_update_ha_state()
+        try:
+            await self.sensor_instance.async_press()
+            _LOGGER.debug(
+                "[%s] Pressed %s",
+                self.device.get_name(),
+                self.sensor_instance.get_description(),
+            )
+            # ask the coordinator to refresh data to all the sensors
+            if self.sensor_instance.get_name() == "refreshData":
+                await self.coordinator.async_request_refresh()
+            # refresh the motionAlarm sensor
+            if self.sensor_instance.get_name() == "refreshAlarm":
+                # update the motionAlarm sensor
+                await self.coordinator.device.get_sensor_by_name(
+                    "motionAlarm"
+                ).async_update()
+                # ask HA to update its state based on the new value
+                for entity in self.coordinator.entities:
+                    if entity.sensor_instance.get_name() in "motionAlarm":
+                        await entity.async_update_ha_state()
+        except ImouException as exception:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="button_action_failed",
+                translation_placeholders={
+                    "action": self.sensor_instance.get_description(),
+                    "error": exception_message(exception),
+                },
+            ) from exception
 
     @property
     def device_class(self) -> str | None:  # type: ignore[override]

--- a/custom_components/imou_life/quality_scale.yaml
+++ b/custom_components/imou_life/quality_scale.yaml
@@ -24,7 +24,7 @@ rules:
   unique-config-entry: done  # Uses device_id as unique_id
 
   # Silver Tier (10 rules) - Stable user experience
-  action-exceptions: todo  # PTZ/battery wrap ImouException; select/button/siren/switch turn_* do not
+  action-exceptions: done  # switch/select/button/siren + battery + camera PTZ wrap ImouException
   config-entry-unloading: done  # async_unload_entry implemented
   docs-configuration-parameters: done  # docs/CONFIGURATION.md
   docs-installation-parameters: done  # docs/INSTALLATION.md

--- a/custom_components/imou_life/select.py
+++ b/custom_components/imou_life/select.py
@@ -3,8 +3,12 @@
 import logging
 
 from homeassistant.components.select import ENTITY_ID_FORMAT, SelectEntity
+from homeassistant.exceptions import HomeAssistantError
+from imouapi.exceptions import ImouException
 
+from .const import DOMAIN
 from .entity import ImouEntity
+from .helpers import exception_message
 from .platform_setup import setup_platform
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -35,8 +39,18 @@ class ImouSelect(ImouEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Se the option."""
-        # control the switch
-        await self.sensor_instance.async_select_option(option)
+        try:
+            await self.sensor_instance.async_select_option(option)
+        except ImouException as exception:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="select_option_failed",
+                translation_placeholders={
+                    "setting": self.sensor_instance.get_description(),
+                    "option": option,
+                    "error": exception_message(exception),
+                },
+            ) from exception
         # save the new state to the state machine (otherwise will be reset by HA
         # and set to the correct value only upon the next update)
         self.async_write_ha_state()

--- a/custom_components/imou_life/siren.py
+++ b/custom_components/imou_life/siren.py
@@ -43,9 +43,8 @@ class ImouSiren(ImouEntity, SirenEntity):
         except ImouException as exception:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="siren_action_failed",
+                translation_key="siren_turn_on_failed",
                 translation_placeholders={
-                    "action": "turn on",
                     "entity": self.sensor_instance.get_description(),
                     "error": exception_message(exception),
                 },
@@ -66,9 +65,8 @@ class ImouSiren(ImouEntity, SirenEntity):
         except ImouException as exception:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="siren_action_failed",
+                translation_key="siren_turn_off_failed",
                 translation_placeholders={
-                    "action": "turn off",
                     "entity": self.sensor_instance.get_description(),
                     "error": exception_message(exception),
                 },
@@ -89,9 +87,8 @@ class ImouSiren(ImouEntity, SirenEntity):
         except ImouException as exception:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="siren_action_failed",
+                translation_key="siren_toggle_failed",
                 translation_placeholders={
-                    "action": "toggle",
                     "entity": self.sensor_instance.get_description(),
                     "error": exception_message(exception),
                 },

--- a/custom_components/imou_life/siren.py
+++ b/custom_components/imou_life/siren.py
@@ -3,8 +3,12 @@
 import logging
 
 from homeassistant.components.siren import SirenEntity, SirenEntityFeature
+from homeassistant.exceptions import HomeAssistantError
+from imouapi.exceptions import ImouException
 
+from .const import DOMAIN
 from .entity import ImouEntity
+from .helpers import exception_message
 from .platform_setup import setup_platform
 
 ENTITY_ID_FORMAT = "siren" + ".{}"
@@ -34,7 +38,18 @@ class ImouSiren(ImouEntity, SirenEntity):
 
     async def async_turn_on(self, **kwargs):  # pylint: disable=unused-argument
         """Turn on the siren."""
-        await self.sensor_instance.async_turn_on()
+        try:
+            await self.sensor_instance.async_turn_on()
+        except ImouException as exception:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="siren_action_failed",
+                translation_placeholders={
+                    "action": "turn on",
+                    "entity": self.sensor_instance.get_description(),
+                    "error": exception_message(exception),
+                },
+            ) from exception
         # save the new state to the state machine (otherwise will be reset by HA
         # and set to the correct value only upon the next update)
         self.async_write_ha_state()
@@ -46,7 +61,18 @@ class ImouSiren(ImouEntity, SirenEntity):
 
     async def async_turn_off(self, **kwargs):  # pylint: disable=unused-argument
         """Turn off the siren."""
-        await self.sensor_instance.async_turn_off()
+        try:
+            await self.sensor_instance.async_turn_off()
+        except ImouException as exception:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="siren_action_failed",
+                translation_placeholders={
+                    "action": "turn off",
+                    "entity": self.sensor_instance.get_description(),
+                    "error": exception_message(exception),
+                },
+            ) from exception
         # save the new state to the state machine (otherwise will be reset by HA
         # and set to the correct value only upon the next update)
         self.async_write_ha_state()
@@ -58,7 +84,18 @@ class ImouSiren(ImouEntity, SirenEntity):
 
     async def async_toggle(self, **kwargs):  # pylint: disable=unused-argument
         """Toggle the siren."""
-        await self.sensor_instance.async_toggle()
+        try:
+            await self.sensor_instance.async_toggle()
+        except ImouException as exception:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="siren_action_failed",
+                translation_placeholders={
+                    "action": "toggle",
+                    "entity": self.sensor_instance.get_description(),
+                    "error": exception_message(exception),
+                },
+            ) from exception
         # save the new state to the state machine (otherwise will be reset by HA
         # and set to the correct value only upon the next update)
         self.async_write_ha_state()

--- a/custom_components/imou_life/switch.py
+++ b/custom_components/imou_life/switch.py
@@ -104,9 +104,8 @@ class ImouSwitch(ImouEntity, SwitchEntity):
         except ImouException as exception:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="switch_action_failed",
+                translation_key="switch_turn_on_failed",
                 translation_placeholders={
-                    "action": "turn on",
                     "entity": self.sensor_instance.get_description(),
                     "error": exception_message(exception),
                 },
@@ -127,9 +126,8 @@ class ImouSwitch(ImouEntity, SwitchEntity):
         except ImouException as exception:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="switch_action_failed",
+                translation_key="switch_turn_off_failed",
                 translation_placeholders={
-                    "action": "turn off",
                     "entity": self.sensor_instance.get_description(),
                     "error": exception_message(exception),
                 },
@@ -150,9 +148,8 @@ class ImouSwitch(ImouEntity, SwitchEntity):
         except ImouException as exception:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
-                translation_key="switch_action_failed",
+                translation_key="switch_toggle_failed",
                 translation_placeholders={
-                    "action": "toggle",
                     "entity": self.sensor_instance.get_description(),
                     "error": exception_message(exception),
                 },

--- a/custom_components/imou_life/switch.py
+++ b/custom_components/imou_life/switch.py
@@ -6,10 +6,12 @@ from collections.abc import Callable
 from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from imouapi.exceptions import ImouException
 
 from .const import DOMAIN, ENABLED_SWITCHES, OPTION_CALLBACK_URL
 from .coordinator import ImouConfigEntry
 from .entity import ImouEntity
+from .helpers import exception_message
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -80,24 +82,35 @@ class ImouSwitch(ImouEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):  # pylint: disable=unused-argument
         """Turn on the switch."""
-        # pushNotifications switch
-        if self.sensor_instance.get_name() == "pushNotifications":
-            callback_url = None
-            # if a callback url is provided as an option, use it as is
-            if (
-                OPTION_CALLBACK_URL in self.config_entry.options
-                and self.config_entry.options[OPTION_CALLBACK_URL] != ""
-            ):
-                callback_url = self.config_entry.options[OPTION_CALLBACK_URL]
-            if callback_url is None:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN, translation_key="no_callback_url"
-                )
-            _LOGGER.debug("Callback URL: %s", callback_url)
-            await self.sensor_instance.async_turn_on(url=callback_url)
-        # control all other switches
-        else:
-            await self.sensor_instance.async_turn_on()
+        try:
+            # pushNotifications switch
+            if self.sensor_instance.get_name() == "pushNotifications":
+                callback_url = None
+                # if a callback url is provided as an option, use it as is
+                if (
+                    OPTION_CALLBACK_URL in self.config_entry.options
+                    and self.config_entry.options[OPTION_CALLBACK_URL] != ""
+                ):
+                    callback_url = self.config_entry.options[OPTION_CALLBACK_URL]
+                if callback_url is None:
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN, translation_key="no_callback_url"
+                    )
+                _LOGGER.debug("Callback URL: %s", callback_url)
+                await self.sensor_instance.async_turn_on(url=callback_url)
+            # control all other switches
+            else:
+                await self.sensor_instance.async_turn_on()
+        except ImouException as exception:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="switch_action_failed",
+                translation_placeholders={
+                    "action": "turn on",
+                    "entity": self.sensor_instance.get_description(),
+                    "error": exception_message(exception),
+                },
+            ) from exception
         # save the new state to the state machine (otherwise will be reset by HA
         # and set to the correct value only upon the next update)
         self.async_write_ha_state()
@@ -109,8 +122,18 @@ class ImouSwitch(ImouEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs):  # pylint: disable=unused-argument
         """Turn off the switch."""
-        # control the switch
-        await self.sensor_instance.async_turn_off()
+        try:
+            await self.sensor_instance.async_turn_off()
+        except ImouException as exception:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="switch_action_failed",
+                translation_placeholders={
+                    "action": "turn off",
+                    "entity": self.sensor_instance.get_description(),
+                    "error": exception_message(exception),
+                },
+            ) from exception
         # save the new state to the state machine (otherwise will be reset by HA
         # and set to the correct value only upon the next update)
         self.async_write_ha_state()
@@ -122,7 +145,18 @@ class ImouSwitch(ImouEntity, SwitchEntity):
 
     async def async_toggle(self, **kwargs):  # pylint: disable=unused-argument
         """Toggle the switch."""
-        await self.sensor_instance.async_toggle()
+        try:
+            await self.sensor_instance.async_toggle()
+        except ImouException as exception:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="switch_action_failed",
+                translation_placeholders={
+                    "action": "toggle",
+                    "entity": self.sensor_instance.get_description(),
+                    "error": exception_message(exception),
+                },
+            ) from exception
         # save the new state to the state machine (otherwise will be reset by HA
         # and set to the correct value only upon the next update)
         self.async_write_ha_state()

--- a/custom_components/imou_life/translations/ca.json
+++ b/custom_components/imou_life/translations/ca.json
@@ -76,5 +76,25 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "switch_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "switch_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "switch_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    },
+    "siren_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "siren_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "siren_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    }
   }
 }

--- a/custom_components/imou_life/translations/en.json
+++ b/custom_components/imou_life/translations/en.json
@@ -132,11 +132,23 @@
     "select_config_failed": {
       "message": "Failed to update config for {setting}: {error}"
     },
-    "switch_action_failed": {
-      "message": "Failed to {action} {entity}: {error}"
+    "switch_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
     },
-    "siren_action_failed": {
-      "message": "Failed to {action} {entity}: {error}"
+    "switch_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "switch_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    },
+    "siren_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "siren_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "siren_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
     },
     "invalid_motion_sensitivity": {
       "message": "Invalid motion sensitivity: {value}"

--- a/custom_components/imou_life/translations/en.json
+++ b/custom_components/imou_life/translations/en.json
@@ -132,6 +132,12 @@
     "select_config_failed": {
       "message": "Failed to update config for {setting}: {error}"
     },
+    "switch_action_failed": {
+      "message": "Failed to {action} {entity}: {error}"
+    },
+    "siren_action_failed": {
+      "message": "Failed to {action} {entity}: {error}"
+    },
     "invalid_motion_sensitivity": {
       "message": "Invalid motion sensitivity: {value}"
     },

--- a/custom_components/imou_life/translations/es-ES.json
+++ b/custom_components/imou_life/translations/es-ES.json
@@ -72,5 +72,25 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "switch_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "switch_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "switch_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    },
+    "siren_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "siren_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "siren_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    }
   }
 }

--- a/custom_components/imou_life/translations/fr.json
+++ b/custom_components/imou_life/translations/fr.json
@@ -72,5 +72,25 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "switch_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "switch_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "switch_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    },
+    "siren_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "siren_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "siren_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    }
   }
 }

--- a/custom_components/imou_life/translations/he.json
+++ b/custom_components/imou_life/translations/he.json
@@ -72,5 +72,25 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "switch_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "switch_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "switch_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    },
+    "siren_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "siren_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "siren_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    }
   }
 }

--- a/custom_components/imou_life/translations/id.json
+++ b/custom_components/imou_life/translations/id.json
@@ -72,5 +72,25 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "switch_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "switch_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "switch_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    },
+    "siren_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "siren_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "siren_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    }
   }
 }

--- a/custom_components/imou_life/translations/it-IT.json
+++ b/custom_components/imou_life/translations/it-IT.json
@@ -72,5 +72,25 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "switch_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "switch_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "switch_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    },
+    "siren_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "siren_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "siren_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    }
   }
 }

--- a/custom_components/imou_life/translations/pt-BR.json
+++ b/custom_components/imou_life/translations/pt-BR.json
@@ -72,5 +72,25 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "switch_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "switch_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "switch_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    },
+    "siren_turn_on_failed": {
+      "message": "Failed to turn on {entity}: {error}"
+    },
+    "siren_turn_off_failed": {
+      "message": "Failed to turn off {entity}: {error}"
+    },
+    "siren_toggle_failed": {
+      "message": "Failed to toggle {entity}: {error}"
+    }
   }
 }

--- a/tests/unit/test_button.py
+++ b/tests/unit/test_button.py
@@ -69,10 +69,17 @@ class TestImouButton:
         assert button.available is True
 
     @pytest.mark.asyncio
-    async def test_button_press(self, button):
-        """Test button press functionality."""
-        await button.async_press()
-        button.sensor_instance.async_press.assert_awaited_once()
+    async def test_button_press_imou_exception(self, button, mock_sensor_instance):
+        """Test button press wraps ImouException in HomeAssistantError."""
+        from homeassistant.exceptions import HomeAssistantError
+        from imouapi.exceptions import ImouException
+
+        mock_sensor_instance.async_press.side_effect = ImouException("API error")
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await button.async_press()
+
+        assert exc_info.value.translation_key == "button_action_failed"
 
     @pytest.mark.asyncio
     async def test_button_press_refresh_data(

--- a/tests/unit/test_button.py
+++ b/tests/unit/test_button.py
@@ -69,6 +69,12 @@ class TestImouButton:
         assert button.available is True
 
     @pytest.mark.asyncio
+    async def test_button_press(self, button):
+        """Test button press functionality."""
+        await button.async_press()
+        button.sensor_instance.async_press.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_button_press_imou_exception(self, button, mock_sensor_instance):
         """Test button press wraps ImouException in HomeAssistantError."""
         from homeassistant.exceptions import HomeAssistantError

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -80,6 +80,12 @@ class TestImouSelect:
         assert select.available is True
 
     @pytest.mark.asyncio
+    async def test_select_select_option(self, select):
+        """Test select option selection."""
+        await select.async_select_option("on")
+        select.sensor_instance.async_select_option.assert_called_once_with("on")
+
+    @pytest.mark.asyncio
     async def test_select_select_option_imou_exception(
         self, select, mock_sensor_instance
     ):

--- a/tests/unit/test_select.py
+++ b/tests/unit/test_select.py
@@ -80,10 +80,21 @@ class TestImouSelect:
         assert select.available is True
 
     @pytest.mark.asyncio
-    async def test_select_select_option(self, select):
-        """Test select option selection."""
-        await select.async_select_option("on")
-        select.sensor_instance.async_select_option.assert_called_once_with("on")
+    async def test_select_select_option_imou_exception(
+        self, select, mock_sensor_instance
+    ):
+        """Test select option wraps ImouException in HomeAssistantError."""
+        from homeassistant.exceptions import HomeAssistantError
+        from imouapi.exceptions import ImouException
+
+        mock_sensor_instance.async_select_option.side_effect = ImouException(
+            "API error"
+        )
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await select.async_select_option("on")
+
+        assert exc_info.value.translation_key == "select_option_failed"
 
     def test_select_device_info(self, select):
         """Test select device info."""

--- a/tests/unit/test_siren.py
+++ b/tests/unit/test_siren.py
@@ -74,6 +74,12 @@ class TestImouSiren:
         assert siren.available is True
 
     @pytest.mark.asyncio
+    async def test_siren_turn_on(self, siren):
+        """Test siren turn on."""
+        await siren.async_turn_on()
+        siren.sensor_instance.async_turn_on.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_siren_turn_on_imou_exception(self, siren, mock_sensor_instance):
         """Test siren turn on wraps ImouException in HomeAssistantError."""
         from homeassistant.exceptions import HomeAssistantError
@@ -84,7 +90,33 @@ class TestImouSiren:
         with pytest.raises(HomeAssistantError) as exc_info:
             await siren.async_turn_on()
 
-        assert exc_info.value.translation_key == "siren_action_failed"
+        assert exc_info.value.translation_key == "siren_turn_on_failed"
+
+    @pytest.mark.asyncio
+    async def test_siren_turn_off_imou_exception(self, siren, mock_sensor_instance):
+        """Test siren turn off wraps ImouException in HomeAssistantError."""
+        from homeassistant.exceptions import HomeAssistantError
+        from imouapi.exceptions import ImouException
+
+        mock_sensor_instance.async_turn_off.side_effect = ImouException("API error")
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await siren.async_turn_off()
+
+        assert exc_info.value.translation_key == "siren_turn_off_failed"
+
+    @pytest.mark.asyncio
+    async def test_siren_toggle_imou_exception(self, siren, mock_sensor_instance):
+        """Test siren toggle wraps ImouException in HomeAssistantError."""
+        from homeassistant.exceptions import HomeAssistantError
+        from imouapi.exceptions import ImouException
+
+        mock_sensor_instance.async_toggle.side_effect = ImouException("API error")
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await siren.async_toggle()
+
+        assert exc_info.value.translation_key == "siren_toggle_failed"
 
     @pytest.mark.asyncio
     async def test_siren_turn_off(self, siren):

--- a/tests/unit/test_siren.py
+++ b/tests/unit/test_siren.py
@@ -74,10 +74,17 @@ class TestImouSiren:
         assert siren.available is True
 
     @pytest.mark.asyncio
-    async def test_siren_turn_on(self, siren):
-        """Test siren turn on."""
-        await siren.async_turn_on()
-        siren.sensor_instance.async_turn_on.assert_called_once()
+    async def test_siren_turn_on_imou_exception(self, siren, mock_sensor_instance):
+        """Test siren turn on wraps ImouException in HomeAssistantError."""
+        from homeassistant.exceptions import HomeAssistantError
+        from imouapi.exceptions import ImouException
+
+        mock_sensor_instance.async_turn_on.side_effect = ImouException("API error")
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await siren.async_turn_on()
+
+        assert exc_info.value.translation_key == "siren_action_failed"
 
     @pytest.mark.asyncio
     async def test_siren_turn_off(self, siren):

--- a/tests/unit/test_switch_comprehensive.py
+++ b/tests/unit/test_switch_comprehensive.py
@@ -273,3 +273,17 @@ class TestImouSwitch:
             assert (
                 switch.entity_registry_enabled_default is True
             ), f"Switch '{switch_name}' should be enabled by default"
+
+    @pytest.mark.asyncio
+    async def test_switch_async_turn_on_imou_exception(
+        self, switch_entity, mock_sensor_instance
+    ):
+        """Test switch turn on wraps ImouException in HomeAssistantError."""
+        from imouapi.exceptions import ImouException
+
+        mock_sensor_instance.async_turn_on.side_effect = ImouException("API error")
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await switch_entity.async_turn_on()
+
+        assert exc_info.value.translation_key == "switch_action_failed"

--- a/tests/unit/test_switch_comprehensive.py
+++ b/tests/unit/test_switch_comprehensive.py
@@ -286,4 +286,32 @@ class TestImouSwitch:
         with pytest.raises(HomeAssistantError) as exc_info:
             await switch_entity.async_turn_on()
 
-        assert exc_info.value.translation_key == "switch_action_failed"
+        assert exc_info.value.translation_key == "switch_turn_on_failed"
+
+    @pytest.mark.asyncio
+    async def test_switch_async_turn_off_imou_exception(
+        self, switch_entity, mock_sensor_instance
+    ):
+        """Test switch turn off wraps ImouException in HomeAssistantError."""
+        from imouapi.exceptions import ImouException
+
+        mock_sensor_instance.async_turn_off.side_effect = ImouException("API error")
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await switch_entity.async_turn_off()
+
+        assert exc_info.value.translation_key == "switch_turn_off_failed"
+
+    @pytest.mark.asyncio
+    async def test_switch_async_toggle_imou_exception(
+        self, switch_entity, mock_sensor_instance
+    ):
+        """Test switch toggle wraps ImouException in HomeAssistantError."""
+        from imouapi.exceptions import ImouException
+
+        mock_sensor_instance.async_toggle.side_effect = ImouException("API error")
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await switch_entity.async_toggle()
+
+        assert exc_info.value.translation_key == "switch_toggle_failed"


### PR DESCRIPTION
## Summary
- Catch ImouException in switch, select, button, and siren platform actions
- Raise translated HomeAssistantError using existing/new exception keys
- Mark Silver tier action-exceptions rule done in quality_scale.yaml

## Test plan
- [x] python -m pytest tests/unit/test_select.py tests/unit/test_button.py tests/unit/test_siren.py tests/unit/test_switch_comprehensive.py -v
- [x] python -m pytest tests/unit/ -q (487 passed)
- [ ] CI green on Quick PR Checks and Comprehensive Validation

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed switch, button, select, and siren actions.
  * Users now receive translated, actionable error messages when device commands fail.
  * Successful device controls continue to work as before.

* **Tests**
  * Added coverage to verify consistent error reporting across supported controls.

* **Documentation**
  * Updated integration quality tracking to reflect completed action-error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->